### PR TITLE
feat: remove --template in favor of positional arguments

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -37,7 +37,7 @@ func generateVariants(cfg *Config) error {
 		"love", "gold", "rose", "pine", "foam", "iris",
 	}
 
-	templateFileInfo, err := os.Stat(cfg.Template)
+	templateFileInfo, err := os.Stat(cfg.File)
 	if err != nil {
 		return fmt.Errorf("failed to open template: %w", err)
 	}
@@ -45,7 +45,7 @@ func generateVariants(cfg *Config) error {
 	var templates []string
 
 	if templateFileInfo.IsDir() {
-		filepath.Walk(cfg.Template, func(path string, info os.FileInfo, err error) error {
+		filepath.Walk(cfg.File, func(path string, info os.FileInfo, err error) error {
 			if !info.IsDir() {
 				templates = append(templates, path)
 			}
@@ -53,7 +53,7 @@ func generateVariants(cfg *Config) error {
 		})
 
 	} else {
-		templates = append(templates, cfg.Template)
+		templates = append(templates, cfg.File)
 	}
 
 	for _, template := range templates {
@@ -151,10 +151,10 @@ func processVariant(cfg *Config, template string, templateContent []byte, accent
 		outputFile = variant.id + ext
 	}
 
-	templateFileInfo, _ := os.Stat(cfg.Template)
+	templateFileInfo, _ := os.Stat(cfg.File)
 
 	if templateFileInfo.IsDir() {
-		dir, _ := strings.CutPrefix(filepath.Dir(template), filepath.Clean(cfg.Template))
+		dir, _ := strings.CutPrefix(filepath.Dir(template), filepath.Clean(cfg.File))
 		if cfg.Accents {
 			outputDir += "/" + accent
 		} else {

--- a/builder_test.go
+++ b/builder_test.go
@@ -110,7 +110,7 @@ func TestAlphaVariables(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template:    templatePath,
+		File:        templatePath,
 		Output:      tmpDir,
 		Format:      "rgb",
 		Prefix:      "$",
@@ -176,7 +176,7 @@ func TestVariantGeneration(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template:    templatePath,
+		File:        templatePath,
 		Output:      tmpDir,
 		Format:      "hex",
 		Prefix:      "$",
@@ -276,9 +276,9 @@ func TestVariantSpecificValues(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template: templatePath,
-		Output:   tmpDir,
-		Prefix:   "$",
+		File:   templatePath,
+		Output: tmpDir,
+		Prefix: "$",
 	}
 
 	if err := Build(cfg); err != nil {
@@ -338,7 +338,7 @@ func TestAccents(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template:    templatePath,
+		File:        templatePath,
 		Output:      tmpDir,
 		Format:      "hex",
 		Prefix:      "$",
@@ -421,7 +421,7 @@ func TestAccentNames(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template:    templatePath,
+		File:        templatePath,
 		Output:      tmpDir,
 		Format:      "hex",
 		Prefix:      "$",
@@ -518,7 +518,7 @@ func TestDirectories(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Template:    filepath.Join(tmpDir, "template"),
+		File:        filepath.Join(tmpDir, "template"),
 		Output:      tmpDir,
 		Format:      "hex",
 		Prefix:      "$",

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package main
 
 type Config struct {
-	Template    string
+	File        string
 	Output      string
 	Prefix      string
 	Format      string

--- a/main.go
+++ b/main.go
@@ -9,8 +9,6 @@ import (
 
 func main() {
 	cfg := &Config{}
-	flag.StringVar(&cfg.Template, "t", "template.json", "Path to template file")
-	flag.StringVar(&cfg.Template, "template", "template.json", "Path to template file")
 	flag.StringVar(&cfg.Output, "o", "dist", "Directory for generated files")
 	flag.StringVar(&cfg.Output, "output", "dist", "Directory for generated files")
 	flag.StringVar(&cfg.Prefix, "p", "$", "Variable prefix")
@@ -23,15 +21,25 @@ func main() {
 	flag.BoolVar(&cfg.Accents, "accents", false, "Generate accent files")
 
 	help := flag.Bool("help", false, "Show help")
-	flag.Bool("h", false, "Show help")
+	help = flag.Bool("h", false, "Show help")
 
 	flag.Parse()
 
 	if *help {
 		fmt.Println("🌱 Bloom - The Rosé Pine theme generator")
 		fmt.Println("\nUsage:")
+		fmt.Println("  Positional Arguments: (note: they must be specified last)")
+		fmt.Println("\t[File] - the file to use")
+		fmt.Println()
 		flag.PrintDefaults()
 		os.Exit(0)
+	}
+
+	if flag.NArg() != 1 {
+		fmt.Println("Required 1 positional argument \"file\", Got", flag.NArg())
+		os.Exit(1)
+	} else {
+		cfg.File = flag.Args()[0]
 	}
 
 	if err := Build(cfg); err != nil {

--- a/readme.md
+++ b/readme.md
@@ -22,31 +22,30 @@ $ rose-pine-bloom --help
 🌱 Bloom - The Rosé Pine theme generator
 
 Usage:
-  -a	Generate accent files
+  Positional Arguments: (note: they must be specified last)
+        [File] - the file to use
+
+  -a    Generate accent files
   -accents
-    	Generate accent files
+        Generate accent files
   -f string
-    	Color output format (default "hex")
+        Color output format (default "hex")
   -format string
-    	Color output format (default "hex")
-  -h	Show help
+        Color output format (default "hex")
+  -h    Show help
   -help
-    	Show help
+        Show help
   -o string
-    	Directory for generated files (default "dist")
+        Directory for generated files (default "dist")
   -output string
-    	Directory for generated files (default "dist")
+        Directory for generated files (default "dist")
   -p string
-    	Variable prefix (default "$")
+        Variable prefix (default "$")
   -prefix string
-    	Variable prefix (default "$")
-  -s	Strip spaces in output
+        Variable prefix (default "$")
+  -s    Strip spaces in output
   -strip-spaces
-    	Strip spaces in output
-  -t string
-    	Path to template file (default "template.json")
-  -template string
-    	Path to template file (default "template.json")
+        Strip spaces in output
 ```
 
 ## Color formats


### PR DESCRIPTION
Completes "Remove --template flag in favour of direct input, e.g. bloom template.json" of #13

it however appears that golangs flag package is a bit janky; as for positional arguments to work, they have to be at the very end of the command. I am not sure of a solution to this, so for now we'll just live with that limitation.