### PR TITLE
feat!: add `--no-commas` flag

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -108,10 +108,10 @@ func processVariant(cfg *Config, template string, templateContent []byte, accent
 			colorCopy := *color
 			normalizedAlpha := alpha / 100
 			colorCopy.Alpha = &normalizedAlpha
-			return formatColor(&colorCopy, ColorFormat(cfg.Format), cfg.Spaces)
+			return formatColor(&colorCopy, ColorFormat(cfg.Format), cfg.Commas, cfg.Spaces)
 		})
 
-		result = strings.ReplaceAll(result, varName, formatColor(color, ColorFormat(cfg.Format), cfg.Spaces))
+		result = strings.ReplaceAll(result, varName, formatColor(color, ColorFormat(cfg.Format), cfg.Commas, cfg.Spaces))
 	}
 
 	result = variantValueRegex.ReplaceAllStringFunc(result, func(match string) string {

--- a/builder_test.go
+++ b/builder_test.go
@@ -17,31 +17,33 @@ func TestColorFormatting(t *testing.T) {
 	tests := []struct {
 		name   string
 		format ColorFormat
+		Commas bool
 		Spaces bool
 		want   string
 	}{
-		{"hex", FormatHex, true, "#ebbcba"},
-		{"hex-ns", FormatHexNS, true, "ebbcba"},
-		{"rgb", FormatRGB, true, "235, 188, 186"},
-		{"rgb", FormatRGB, false, "235,188,186"},
-		{"rgb-ns", FormatRGBNS, true, "235 188 186"},
-		{"rgb-ansi", FormatRGBAnsi, true, "235;188;186"},
-		{"rgb-array", FormatRGBArray, true, "[235, 188, 186]"},
-		{"rgb-array", FormatRGBArray, false, "[235,188,186]"},
-		{"rgb-function", FormatRGBFunc, true, "rgb(235, 188, 186)"},
-		{"rgb-function", FormatRGBFunc, false, "rgb(235,188,186)"},
-		{"hsl", FormatHSL, true, "2, 55%, 83%"},
-		{"hsl", FormatHSL, false, "2,55%,83%"},
-		{"hsl-ns", FormatHSLNS, true, "2 55% 83%"},
-		{"hsl-array", FormatHSLArray, true, "[2, 55%, 83%]"},
-		{"hsl-array", FormatHSLArray, false, "[2,55%,83%]"},
-		{"hsl-function", FormatHSLFunc, true, "hsl(2, 55%, 83%)"},
-		{"hsl-function", FormatHSLFunc, false, "hsl(2,55%,83%)"},
+		{"hex", FormatHex, true, true, "#ebbcba"},
+		{"hex-ns", FormatHexNS, true, true, "ebbcba"},
+		{"rgb", FormatRGB, true, true, "235, 188, 186"},
+		{"rgb no-spaces", FormatRGB, true, false, "235,188,186"},
+		{"rgb no-commas", FormatRGB, false, true, "235 188 186"},
+		{"rgb-ansi", FormatRGBAnsi, true, true, "235;188;186"},
+		{"rgb-array", FormatRGBArray, true, true, "[235, 188, 186]"},
+		{"rgb-array", FormatRGBArray, true, false, "[235,188,186]"},
+		{"rgb-function", FormatRGBFunc, true, true, "rgb(235, 188, 186)"},
+		{"rgb-function no-commas", FormatRGBFunc, false, true, "rgb(235 188 186)"},
+		{"rgb-function", FormatRGBFunc, true, false, "rgb(235,188,186)"},
+		{"hsl", FormatHSL, true, true, "2, 55%, 83%"},
+		{"hsl no-spaces", FormatHSL, true, false, "2,55%,83%"},
+		{"hsl no-commas", FormatHSL, false, true, "2 55% 83%"},
+		{"hsl-array", FormatHSLArray, true, true, "[2, 55%, 83%]"},
+		{"hsl-array", FormatHSLArray, true, false, "[2,55%,83%]"},
+		{"hsl-function", FormatHSLFunc, true, true, "hsl(2, 55%, 83%)"},
+		{"hsl-function no-spaces", FormatHSLFunc, true, false, "hsl(2,55%,83%)"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatColor(color, tt.format, tt.Spaces)
+			got := formatColor(color, tt.format, tt.Commas, tt.Spaces)
 			if got != tt.want {
 				t.Errorf("formatColor() = %v, want %v", got, tt.want)
 			}
@@ -61,26 +63,27 @@ func TestColorFormattingWithAlpha(t *testing.T) {
 	tests := []struct {
 		name   string
 		format ColorFormat
+		Commas bool
 		Spaces bool
 		want   string
 	}{
-		{"rgb with alpha", FormatRGB, true, "235, 188, 186, 0.5"},
-		{"rgb-ns with alpha", FormatRGBNS, true, "235 188 186 0.5"},
-		{"rgb-ansi with alpha", FormatRGBAnsi, true, "235;188;186;0.5"},
-		{"rgb-array with alpha", FormatRGBArray, true, "[235, 188, 186, 0.5]"},
-		{"rgb-function with alpha", FormatRGBFunc, true, "rgba(235, 188, 186, 0.5)"},
-		{"hsl with alpha", FormatHSL, true, "2, 55%, 83%, 0.5"},
-		{"hsl-ns with alpha", FormatHSLNS, true, "2 55% 83% 0.5"},
-		{"hsl-array with alpha", FormatHSLArray, true, "[2, 55%, 83%, 0.5]"},
-		{"hsl-function with alpha", FormatHSLFunc, true, "hsla(2, 55%, 83%, 0.5)"},
+		{"rgb with alpha", FormatRGB, true, true, "235, 188, 186, 0.5"},
+		{"rgb no-commas with alpha", FormatRGB, false, true, "235 188 186 0.5"},
+		{"rgb-ansi with alpha", FormatRGBAnsi, true, true, "235;188;186;0.5"},
+		{"rgb-array with alpha", FormatRGBArray, true, true, "[235, 188, 186, 0.5]"},
+		{"rgb-function with alpha", FormatRGBFunc, true, true, "rgba(235, 188, 186, 0.5)"},
+		{"hsl with alpha", FormatHSL, true, true, "2, 55%, 83%, 0.5"},
+		{"hsl no-commas with alpha", FormatHSL, false, true, "2 55% 83% 0.5"},
+		{"hsl-array with alpha", FormatHSLArray, true, true, "[2, 55%, 83%, 0.5]"},
+		{"hsl-function with alpha", FormatHSLFunc, true, true, "hsla(2, 55%, 83%, 0.5)"},
 
-		{"rgb-array with alpha stripped", FormatRGBArray, false, "[235,188,186,0.5]"},
-		{"hsl-array with alpha stripped", FormatHSLArray, false, "[2,55%,83%,0.5]"},
+		{"rgb-array no-spaces with alpha", FormatRGBArray, true, false, "[235,188,186,0.5]"},
+		{"hsl-array no-spaces with alpha", FormatHSLArray, true, false, "[2,55%,83%,0.5]"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatColor(color, tt.format, tt.Spaces)
+			got := formatColor(color, tt.format, tt.Commas, tt.Spaces)
 			if got != tt.want {
 				t.Errorf("formatColor() = %v, want %v", got, tt.want)
 			}
@@ -112,6 +115,7 @@ func TestAlphaVariables(t *testing.T) {
 		Output:   tmpDir,
 		Format:   "rgb",
 		Prefix:   "$",
+		Commas:   true,
 		Spaces:   true,
 	}
 

--- a/color.go
+++ b/color.go
@@ -12,7 +12,8 @@ type Color struct {
 	Alpha *float64   `json:"alpha,omitempty"`
 }
 
-func formatColor(c *Color, format ColorFormat, spaces bool) string {
+func formatColor(c *Color, format ColorFormat, commas bool, spaces bool) string {
+	workingString := ""
 	formatAlpha := func(alpha float64) string {
 		s := fmt.Sprintf("%.2f", alpha)
 		s = strings.TrimRight(s, "0")
@@ -22,27 +23,39 @@ func formatColor(c *Color, format ColorFormat, spaces bool) string {
 
 	switch format {
 	case FormatHex:
-		return "#" + c.Hex
+		workingString = "#" + c.Hex
 	case FormatHexNS:
-		return c.Hex
+		workingString = c.Hex
+	case FormatHSL:
+		hsl := fmt.Sprintf("%v, %v%%, %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
+		if c.Alpha != nil {
+			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
+		}
+		workingString = hsl
+	case FormatHSLArray:
+		hsl := fmt.Sprintf("[%v, %v%%, %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
+		if c.Alpha != nil {
+			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
+		}
+		hsl += "]"
+		workingString = hsl
+	case FormatHSLFunc:
+		prefix := "hsl"
+		if c.Alpha != nil {
+			prefix = "hsla"
+		}
+		hsl := fmt.Sprintf("%s(%v, %v%%, %v%%", prefix, c.HSL[0], c.HSL[1], c.HSL[2])
+		if c.Alpha != nil {
+			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
+		}
+		hsl += ")"
+		workingString = hsl
 	case FormatRGB:
 		rgb := fmt.Sprintf("%d, %d, %d", c.RGB[0], c.RGB[1], c.RGB[2])
 		if c.Alpha != nil {
 			rgb += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
 		}
-		if spaces == false {
-			return strings.ReplaceAll(rgb, " ", "")
-		}
-		return rgb
-	case FormatRGBNS:
-		rgb := fmt.Sprintf("%d %d %d", c.RGB[0], c.RGB[1], c.RGB[2])
-		if c.Alpha != nil {
-			rgb += fmt.Sprintf(" %s", formatAlpha(*c.Alpha))
-		}
-		if spaces == false {
-			return strings.ReplaceAll(rgb, " ", "")
-		}
-		return rgb
+		workingString = rgb
 	case FormatRGBAnsi:
 		if c.Alpha != nil {
 			return fmt.Sprintf("%d;%d;%d;%s", c.RGB[0], c.RGB[1], c.RGB[2], formatAlpha(*c.Alpha))
@@ -54,10 +67,7 @@ func formatColor(c *Color, format ColorFormat, spaces bool) string {
 			rgb += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
 		}
 		rgb += "]"
-		if spaces == false {
-			return strings.ReplaceAll(rgb, " ", "")
-		}
-		return rgb
+		workingString = rgb
 	case FormatRGBFunc:
 		prefix := "rgb"
 		if c.Alpha != nil {
@@ -68,53 +78,17 @@ func formatColor(c *Color, format ColorFormat, spaces bool) string {
 			rgb += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
 		}
 		rgb += ")"
-		if spaces == false {
-			return strings.ReplaceAll(rgb, " ", "")
-		}
-		return rgb
-	case FormatHSL:
-		hsl := fmt.Sprintf("%v, %v%%, %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
-		if c.Alpha != nil {
-			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
-		}
-		if spaces == false {
-			return strings.ReplaceAll(hsl, " ", "")
-		}
-		return hsl
-	case FormatHSLNS:
-		hsl := fmt.Sprintf("%v %v%% %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
-		if c.Alpha != nil {
-			hsl += fmt.Sprintf(" %s", formatAlpha(*c.Alpha))
-		}
-		if spaces == false {
-			return strings.ReplaceAll(hsl, " ", "")
-		}
-		return hsl
-	case FormatHSLArray:
-		hsl := fmt.Sprintf("[%v, %v%%, %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
-		if c.Alpha != nil {
-			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
-		}
-		hsl += "]"
-		if spaces == false {
-			return strings.ReplaceAll(hsl, " ", "")
-		}
-		return hsl
-	case FormatHSLFunc:
-		prefix := "hsl"
-		if c.Alpha != nil {
-			prefix = "hsla"
-		}
-		hsl := fmt.Sprintf("%s(%v, %v%%, %v%%", prefix, c.HSL[0], c.HSL[1], c.HSL[2])
-		if c.Alpha != nil {
-			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
-		}
-		hsl += ")"
-		if spaces == false {
-			return strings.ReplaceAll(hsl, " ", "")
-		}
-		return hsl
+		workingString = rgb
 	default:
-		return "#" + c.Hex
+		workingString = "#" + c.Hex
 	}
+
+	if commas == false {
+		workingString = strings.ReplaceAll(workingString, ",", "")
+	}
+	if spaces == false {
+		workingString = strings.ReplaceAll(workingString, " ", "")
+	}
+
+	return workingString
 }

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	Prefix   string
 	Format   string
 	Accents  bool
+	Commas   bool
 	Spaces   bool
 }
 
@@ -15,12 +16,10 @@ const (
 	FormatHex      ColorFormat = "hex"
 	FormatHexNS    ColorFormat = "hex-ns"
 	FormatRGB      ColorFormat = "rgb"
-	FormatRGBNS    ColorFormat = "rgb-ns"
 	FormatRGBAnsi  ColorFormat = "rgb-ansi"
 	FormatRGBArray ColorFormat = "rgb-array"
 	FormatRGBFunc  ColorFormat = "rgb-function"
 	FormatHSL      ColorFormat = "hsl"
-	FormatHSLNS    ColorFormat = "hsl-ns"
 	FormatHSLArray ColorFormat = "hsl-array"
 	FormatHSLFunc  ColorFormat = "hsl-function"
 )

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	cfg      = &Config{}
+	noCommas bool
 	noSpaces bool
 	showHelp bool
 )
@@ -54,6 +55,7 @@ func printHelp() {
     -p, --prefix <string>  Color variable prefix (default: $)
     -f, --format <format>  Color output format (default: hex)
 
+    --no-commas            Remove commas from color values
     --no-spaces            Remove spaces from color values
 
     -h, --help             Show help
@@ -63,12 +65,10 @@ func printHelp() {
     hex-ns        c4a7e7
 
     hsl           267, 57%%, 78%%
-    hsl-ns        267 57%% 78%%
     hsl-array     [267, 57%%, 78%%]
     hsl-function  hsl(267, 57%%, 78%%)
 
     rgb           196, 167, 231
-    rgb-ns        196 167 231
     rgb-ansi      196;167;231
     rgb-array     [196, 167, 231]
     rgb-function  rgb(196, 167, 231)
@@ -94,6 +94,7 @@ func main() {
 	flag.BoolVar(&cfg.Accents, "a", false, "")
 	flag.BoolVar(&cfg.Accents, "accents", false, "")
 
+	flag.BoolVar(&noCommas, "no-commas", false, "")
 	flag.BoolVar(&noSpaces, "no-spaces", false, "")
 
 	flag.BoolVar(&showHelp, "h", false, "")
@@ -115,6 +116,7 @@ func main() {
 	}
 
 	cfg.Template = template
+	cfg.Commas = !noCommas
 	cfg.Spaces = !noSpaces
 
 	if err := Build(cfg); err != nil {

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ $ bloom --help
     -p, --prefix <string>  Color variable prefix (default: $)
     -f, --format <format>  Color output format (default: hex)
 
+    --no-commas            Remove commas from color values
     --no-spaces            Remove spaces from color values
 
     -h, --help             Show help
@@ -39,12 +40,10 @@ $ bloom --help
     hex-ns        c4a7e7
 
     hsl           267, 57%, 78%
-    hsl-ns        267 57% 78%
     hsl-array     [267, 57%, 78%]
     hsl-function  hsl(267, 57%, 78%)
 
     rgb           196, 167, 231
-    rgb-ns        196 167 231
     rgb-ansi      196;167;231
     rgb-array     [196, 167, 231]
     rgb-function  rgb(196, 167, 231)


### PR DESCRIPTION
This pull request removes the `<hsl,rgb>-ns` formats in favour of a unified `--no-commas` flag. The "ns" suffix, although created by me, has always confused me. My first thought is that it stands for "no spaces" which is untrue; it stands for "no styles" since it was used to remove the hex "#" and HSL/RGB commas.

In the future, I'd like to rename `hex-ns` to something more self-explanatory but need to noodle that.