### PR TITLE
chore: generate usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all build update-readme-help
+
+all: build update-readme-help
+
+build:
+	go build
+
+update-readme-help:
+	./script/update-readme-help.sh

--- a/builder.go
+++ b/builder.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 )
 
 func Build(cfg *Config) error {
@@ -49,31 +48,6 @@ func generateTemplates(cfg *Config) error {
 	}
 
 	return nil
-}
-
-type format struct {
-	Name    string
-	Example string
-}
-
-func printFormats() {
-	formats := [...]format{
-		{Name: "hex", Example: "#ebbcba"},
-		{Name: "hex-ns", Example: "ebbcba"},
-		{Name: "rgb", Example: "235, 188, 186"},
-		{Name: "rbg-ansi", Example: "235;188;186"},
-		{Name: "rgb-array", Example: "[235, 188, 186]"},
-		{Name: "rgb-function", Example: "rgb(235, 188, 186)"},
-		{Name: "hsl", Example: "2, 55%, 83%"},
-		{Name: "hsl-array", Example: "[2, 55%, 83%]"},
-		{Name: "hsl-function", Example: "hsl(2, 55%, 83%)"},
-	}
-
-	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-	for _, f := range formats {
-		fmt.Fprintln(w, "    ", "- ", f.Name, "\t", f.Example)
-	}
-	w.Flush()
 }
 
 var variants = []struct {
@@ -121,7 +95,7 @@ func createTemplate(cfg *Config, file string, fileContent []byte) error {
 		var Yellow = "\033[33m"
 		var Reset = "\033[0m"
 		fmt.Printf(Yellow+"No matches for specified format (%s). Available formats:\n"+Reset, ColorFormat(cfg.Format))
-		printFormats()
+		PrintFormatsTable()
 	}
 
 	var outputFile, outputDir string

--- a/main.go
+++ b/main.go
@@ -43,48 +43,6 @@ func detectTemplate(args []string) (string, error) {
 	}
 }
 
-func printHelp() {
-	helpMessage := fmt.Sprintf(`
-  🌱 Bloom - The Rosé Pine theme generator
-
-  Usage
-    $ %s [options] <template>
-
-  Options
-    -o, --output <path>     Directory for generated files (default: dist)
-    -p, --prefix <string>   Color variable prefix (default: $)
-    -f, --format <format>   Color output format (default: hex)
-    -c, --create <variant>  Create template from existing theme (default: main)
-                            Variants: main, moon, dawn
-
-    --accents               Create themes for each accent color
-    --no-commas             Remove commas from color values
-    --no-spaces             Remove spaces from color values
-
-    -h, --help              Show help
-
-  Formats
-    hex           #c4a7e7
-    hex-ns        c4a7e7
-
-    hsl           267, 57%%, 78%%
-    hsl-array     [267, 57%%, 78%%]
-    hsl-function  hsl(267, 57%%, 78%%)
-
-    rgb           196, 167, 231
-    rgb-ansi      196;167;231
-    rgb-array     [196, 167, 231]
-    rgb-function  rgb(196, 167, 231)
-
-  Examples
-    $ rose-pine-bloom template.yaml
-    $ rose-pine-bloom -f hsl -o dist template.json
-    $ rose-pine-bloom -c dawn my-theme.toml
-
-`, os.Args[0])
-	fmt.Fprint(os.Stderr, helpMessage)
-}
-
 func main() {
 	flag.StringVar(&cfg.Output, "o", "dist", "")
 	flag.StringVar(&cfg.Output, "output", "dist", "")
@@ -107,7 +65,7 @@ func main() {
 	flag.Parse()
 
 	if showHelp {
-		printHelp()
+		PrintHelp()
 		return
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,16 @@
 
 Start by creating a template file. This will look similar to your desired theme file, replacing colour values with Rosé Pine variables. For example, `#ebbcba` would now be `$rose`. Already have a theme? You can [create a template](#create-a-template) from an existing theme.
 
+<!-- HELP_START -->
+<!-- DO NOT EDIT BELOW THIS LINE! This section is auto-generated. -->
+
 ```
-$ rose-pine-bloom --help
+$ ./rose-pine-bloom --help
 
   🌱 Bloom - The Rosé Pine theme generator
 
   Usage
-    $ rose-pine-bloom <template> [options]
+    $ ./rose-pine-bloom [options] <template>
 
   Options
     -o, --output <path>     Directory for generated files (default: dist)
@@ -39,23 +42,23 @@ $ rose-pine-bloom --help
     -h, --help              Show help
 
   Formats
-    hex           #c4a7e7
-    hex-ns        c4a7e7
-
-    hsl           267, 57%, 78%
-    hsl-array     [267, 57%, 78%]
-    hsl-function  hsl(267, 57%, 78%)
-
-    rgb           196, 167, 231
-    rgb-ansi      196;167;231
-    rgb-array     [196, 167, 231]
-    rgb-function  rgb(196, 167, 231)
+    hex           #ebbcba
+    hex-ns        ebbcba
+    hsl           2, 55%, 83%
+    hsl-array     [2, 55%, 83%]
+    hsl-function  hsl(2, 55%, 83%)
+    rgb           235, 188, 186
+    rgb-ansi      235;188;186
+    rgb-array     [235, 188, 186]
+    rgb-function  rgb(235, 188, 186)
 
   Examples
-    $ rose-pine-bloom template.yaml
-    $ rose-pine-bloom -f hsl -o dist template.json
-    $ rose-pine-bloom -c dawn my-theme.toml
+    $ ./rose-pine-bloom template.yaml
+    $ ./rose-pine-bloom -f hsl -o dist template.json
+    $ ./rose-pine-bloom -c dawn my-theme.toml
+
 ```
+<!-- HELP_END -->
 
 ## Create a template
 

--- a/script/update-readme-help.sh
+++ b/script/update-readme-help.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+README="readme.md"
+BINARY="./rose-pine-bloom"
+HELP_TMP="$(mktemp)"
+
+if [ ! -x "$BINARY" ]; then
+	echo "Building $BINARY..."
+	go build -o $BINARY .
+fi
+
+echo "\$ $BINARY --help" >"$HELP_TMP"
+$BINARY --help >>"$HELP_TMP" 2>&1
+
+awk -v helpfile="$HELP_TMP" '
+    BEGIN { in_block=0 }
+    /<!-- HELP_START -->/ {
+        print;
+        print "<!-- DO NOT EDIT BELOW THIS LINE! This section is auto-generated. -->";
+        print "";
+        print "```";
+        while ((getline line < helpfile) > 0) print line;
+        close(helpfile);
+        print "```";
+        in_block=1;
+        next
+    }
+    /<!-- HELP_END -->/ { in_block=0 }
+    !in_block
+' "$README" >"${README}.tmp" && mv "${README}.tmp" "$README"
+
+rm "$HELP_TMP"
+
+echo "✓ Updated $README with latest help output."

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+type format struct {
+	Name    string
+	Example string
+}
+
+var formats = [...]format{
+	{Name: "hex", Example: "#ebbcba"},
+	{Name: "hex-ns", Example: "ebbcba"},
+	{Name: "hsl", Example: "2, 55%, 83%"},
+	{Name: "hsl-array", Example: "[2, 55%, 83%]"},
+	{Name: "hsl-function", Example: "hsl(2, 55%, 83%)"},
+	{Name: "rgb", Example: "235, 188, 186"},
+	{Name: "rgb-ansi", Example: "235;188;186"},
+	{Name: "rgb-array", Example: "[235, 188, 186]"},
+	{Name: "rgb-function", Example: "rgb(235, 188, 186)"},
+}
+
+func formatsTable() string {
+	var sb strings.Builder
+	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
+	for _, f := range formats {
+		fmt.Fprintf(w, "    %-13s %s\n", f.Name, f.Example)
+	}
+	w.Flush()
+	return sb.String()
+}
+
+func PrintFormatsTable() {
+	fmt.Fprint(os.Stdout, formatsTable())
+}
+
+func helpText() string {
+	return fmt.Sprintf(`
+  🌱 Bloom - The Rosé Pine theme generator
+
+  Usage
+    $ %s [options] <template>
+
+  Options
+    -o, --output <path>     Directory for generated files (default: dist)
+    -p, --prefix <string>   Color variable prefix (default: $)
+    -f, --format <format>   Color output format (default: hex)
+    -c, --create <variant>  Create template from existing theme (default: main)
+                            Variants: main, moon, dawn
+
+    --accents               Create themes for each accent color
+    --no-commas             Remove commas from color values
+    --no-spaces             Remove spaces from color values
+
+    -h, --help              Show help
+
+  Formats
+%s
+  Examples
+    $ %[1]s template.yaml
+    $ %[1]s -f hsl -o dist template.json
+    $ %[1]s -c dawn my-theme.toml
+
+`, os.Args[0], formatsTable())
+}
+
+func PrintHelp() {
+	fmt.Fprint(os.Stderr, helpText())
+}


### PR DESCRIPTION
This pull request streamlines our usage documentation. We write our messages once in the new `usage.go`. Running `make` will build the go app and generate the usage for our readme.

Closes #21 