### PR TITLE
chore: update release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,10 +44,10 @@ jobs:
           ext=""
           if [ "${{ matrix.os }}" = "windows" ]; then ext=".exe"; fi
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o dist/${FILENAME}${ext}
-          cd dist
-          zip ${FILENAME}.zip ${FILENAME}${ext}
-          cd ..
       - name: Upload to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} dist/${FILENAME}.zip
+        run: |
+          ext=""
+          if [ "${{ matrix.os }}" = "windows" ]; then ext=".exe"; fi
+          gh release upload ${{ needs.release-please.outputs.tag_name }} dist/${FILENAME}${ext}


### PR DESCRIPTION
I keep iterating on this and not really knowing what I'm doing. I'm trying to understand each line but it's hard to test without creating new releases. My main curiosities are:

- Is the `GITHUB_TOKEN` actually needed or does `gh` already know about the special `{{ secrets.GITHUB_TOKEN }}` like release-please?
- Is there a builtin way in go to change the output while still letting `go build` automatically add the `.exe` on windows? I believe `go build -o ./dist` works but then we lose the os and arch in the filename.