### PR TITLE
add -c / --create flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func main() {
 	flag.StringVar(&cfg.Output, "o", "dist", "")
 	flag.StringVar(&cfg.Output, "output", "dist", "")
 
+	flag.StringVar(&cfg.Create, "c", "", "")
+	flag.StringVar(&cfg.Create, "create", "", "")
+
 	flag.StringVar(&cfg.Prefix, "p", "$", "")
 	flag.StringVar(&cfg.Prefix, "prefix", "$", "")
 


### PR DESCRIPTION
somehow, adding the -c / --create flag was *missed*, this PR adds that flag back

and, yes, this also means that the 2.0.0 release, has the feature, but no interface to use it.
so maybe consider rebuilding that release with this commit maybe???

@mvllow
just kind of shocked how this even happened