### PR TITLE
feat: show help for invalid usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,10 @@ func detectTemplate(args []string) (string, error) {
 	}
 }
 
+func init() {
+	flag.Usage = PrintHelp
+}
+
 func main() {
 	flag.StringVar(&cfg.Output, "o", "dist", "")
 	flag.StringVar(&cfg.Output, "output", "dist", "")


### PR DESCRIPTION
Be default, available flags are shown when invalid flags are given. This commit ensures our help is shown instead, giving more usage context.