### PR TITLE
feat!: remove duplicated formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,19 @@ $ ./rose-pine-bloom --help
 
   Formats
     hex           #ebbcba
-    hex-ns        ebbcba
-    hsl           2, 55%, 83%
-    hsl-array     [2, 55%, 83%]
+    hex --plain   ebbcba
+    hsl           hsl(2, 55%, 83%)
+    hsl --plain   2, 55%, 83%
     hsl-css       hsl(2deg 55% 83%)
-    hsl-function  hsl(2, 55%, 83%)
-    rgb           235, 188, 186
-    rgb-array     [235, 188, 186]
+    hsl-css --plain 2deg 55% 83%
+    hsl-array     [2, 55%, 83%]
+    hsl-array --plain 2, 55%, 83%
+    rgb           rgb(235, 188, 186)
+    rgb --plain   235, 188, 186
     rgb-css       rgb(235 188 186)
-    rgb-function  rgb(235, 188, 186)
+    rgb-css --plain 235 188 186
+    rgb-array     [235, 188, 186]
+    rgb-array --plain 235, 188, 186
     ansi          235;188;186
 
   Examples

--- a/builder_test.go
+++ b/builder_test.go
@@ -42,38 +42,38 @@ func TestColorFormatting(t *testing.T) {
 		spaces bool
 		want   string
 	}{
-		// Hex formats
 		{"hex", FormatHex, false, true, true, "#ebbcba"},
 		{"hex plain", FormatHex, true, true, true, "ebbcba"},
 
-		// HSL formats
-		{"hsl", FormatHSL, false, true, true, "2, 55%, 83%"},
-		{"hsl no-commas", FormatHSL, false, false, true, "2 55% 83%"},
-		{"hsl no-spaces", FormatHSL, false, true, false, "2,55%,83%"},
+		{"hsl", FormatHSL, false, true, true, "hsl(2, 55%, 83%)"},
+		{"hsl no-commas", FormatHSL, false, false, true, "hsl(2 55% 83%)"},
+		{"hsl no-spaces", FormatHSL, false, true, false, "hsl(2,55%,83%)"},
+		{"hsl plain", FormatHSL, true, true, true, "2, 55%, 83%"},
+		{"hsl plain no-commas", FormatHSL, true, false, true, "2 55% 83%"},
+		{"hsl plain no-spaces", FormatHSL, true, true, false, "2,55%,83%"},
+
 		{"hsl-array", FormatHSLArray, false, true, true, "[2, 55%, 83%]"},
 		{"hsl-array plain", FormatHSLArray, true, true, true, "2, 55%, 83%"},
 		{"hsl-array no-commas", FormatHSLArray, false, false, true, "[2 55% 83%]"},
 		{"hsl-array no-spaces", FormatHSLArray, false, true, false, "[2,55%,83%]"},
+
 		{"hsl-css", FormatHSLCSS, false, true, true, "hsl(2deg 55% 83%)"},
 		{"hsl-css plain", FormatHSLCSS, true, true, true, "2deg 55% 83%"},
-		{"hsl-function", FormatHSLFunc, false, true, true, "hsl(2, 55%, 83%)"},
-		{"hsl-function plain", FormatHSLFunc, true, true, true, "2, 55%, 83%"},
-		{"hsl-function no-commas", FormatHSLFunc, false, false, true, "hsl(2 55% 83%)"},
-		{"hsl-function no-spaces", FormatHSLFunc, false, true, false, "hsl(2,55%,83%)"},
 
-		// RGB formats
-		{"rgb", FormatRGB, false, true, true, "235, 188, 186"},
-		{"rgb no-spaces", FormatRGB, false, true, false, "235,188,186"},
-		{"rgb no-commas", FormatRGB, false, false, true, "235 188 186"},
+		{"rgb", FormatRGB, false, true, true, "rgb(235, 188, 186)"},
+		{"rgb no-commas", FormatRGB, false, false, true, "rgb(235 188 186)"},
+		{"rgb no-spaces", FormatRGB, false, true, false, "rgb(235,188,186)"},
+		{"rgb plain", FormatRGB, true, true, true, "235, 188, 186"},
+		{"rgb plain no-commas", FormatRGB, true, false, true, "235 188 186"},
+		{"rgb plain no-spaces", FormatRGB, true, true, false, "235,188,186"},
+
 		{"rgb-array", FormatRGBArray, false, true, true, "[235, 188, 186]"},
 		{"rgb-array plain", FormatRGBArray, true, true, true, "235, 188, 186"},
+		{"rgb-array no-commas", FormatRGBArray, false, false, true, "[235 188 186]"},
 		{"rgb-array no-spaces", FormatRGBArray, false, true, false, "[235,188,186]"},
+
 		{"rgb-css", FormatRGBCSS, false, true, true, "rgb(235 188 186)"},
 		{"rgb-css plain", FormatRGBCSS, true, true, true, "235 188 186"},
-		{"rgb-function", FormatRGBFunc, false, true, true, "rgb(235, 188, 186)"},
-		{"rgb-function plain", FormatRGBFunc, true, true, true, "235, 188, 186"},
-		{"rgb-function no-commas", FormatRGBFunc, false, false, true, "rgb(235 188 186)"},
-		{"rgb-function no-spaces", FormatRGBFunc, false, true, false, "rgb(235,188,186)"},
 
 		{"ansi", FormatAnsi, false, true, true, "235;188;186"},
 	}
@@ -103,15 +103,13 @@ func TestAlphaFormatting(t *testing.T) {
 	}{
 		{FormatHex, "#ebbcba80"},
 
-		{FormatHSL, "2, 55%, 83%, 0.5"},
-		{FormatHSLArray, "[2, 55%, 83%, 0.5]"},
+		{FormatHSL, "hsla(2, 55%, 83%, 0.5)"},
 		{FormatHSLCSS, "hsl(2deg 55% 83% / 0.5)"},
-		{FormatHSLFunc, "hsla(2, 55%, 83%, 0.5)"},
+		{FormatHSLArray, "[2, 55%, 83%, 0.5]"},
 
-		{FormatRGB, "235, 188, 186, 0.5"},
-		{FormatRGBArray, "[235, 188, 186, 0.5]"},
+		{FormatRGB, "rgba(235, 188, 186, 0.5)"},
 		{FormatRGBCSS, "rgb(235 188 186 / 0.5)"},
-		{FormatRGBFunc, "rgba(235, 188, 186, 0.5)"},
+		{FormatRGBArray, "[235, 188, 186, 0.5]"},
 
 		{FormatAnsi, "235;188;186;0.5"},
 	}
@@ -132,10 +130,9 @@ func TestAlphaVariables(t *testing.T) {
 	defer cleanup()
 
 	templateContent := `{
-        "regular": "$base",
-        "alpha50": "$base/50",
-        "alpha25": "$base/25",
-        "alphaMuted50": "$muted/50"
+        "muted": "$muted",
+        "muted10": "$muted/10",
+        "muted20": "$muted/20"
     }`
 
 	cfg := &Config{
@@ -162,10 +159,9 @@ func TestAlphaVariables(t *testing.T) {
 		field string
 		want  string
 	}{
-		{"regular", "25, 23, 36"},
-		{"alpha50", "25, 23, 36, 0.5"},
-		{"alpha25", "25, 23, 36, 0.25"},
-		{"alphaMuted50", "110, 106, 134, 0.5"},
+		{"muted", "rgb(110, 106, 134)"},
+		{"muted10", "rgba(110, 106, 134, 0.1)"},
+		{"muted20", "rgba(110, 106, 134, 0.2)"},
 	}
 
 	for _, tt := range tests {

--- a/colors.go
+++ b/colors.go
@@ -40,12 +40,6 @@ func formatColor(c *Color, format ColorFormat, plain bool, commas bool, spaces b
 		if c.Alpha != nil {
 			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
 		}
-		workingString = hsl
-	case FormatHSLFunc:
-		hsl := fmt.Sprintf("%v, %v%%, %v%%", c.HSL[0], c.HSL[1], c.HSL[2])
-		if c.Alpha != nil {
-			hsl += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
-		}
 		prefix := "hsl"
 		if c.Alpha != nil {
 			prefix = "hsla"
@@ -76,11 +70,19 @@ func formatColor(c *Color, format ColorFormat, plain bool, commas bool, spaces b
 			workingString = "[" + hslArray + "]"
 		}
 	case FormatRGB:
-		rgb := fmt.Sprintf("%d, %d, %d", c.RGB[0], c.RGB[1], c.RGB[2])
+		rgb := fmt.Sprintf("%v, %v, %v", c.RGB[0], c.RGB[1], c.RGB[2])
 		if c.Alpha != nil {
 			rgb += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
 		}
-		workingString = rgb
+		prefix := "rgb"
+		if c.Alpha != nil {
+			prefix = "rgba"
+		}
+		if plain {
+			workingString = rgb
+		} else {
+			workingString = fmt.Sprintf("%s(%s)", prefix, rgb)
+		}
 	case FormatRGBCSS:
 		rgb := fmt.Sprintf("%v %v %v", c.RGB[0], c.RGB[1], c.RGB[2])
 		if c.Alpha != nil {
@@ -100,20 +102,6 @@ func formatColor(c *Color, format ColorFormat, plain bool, commas bool, spaces b
 			workingString = rgbArray
 		} else {
 			workingString = "[" + rgbArray + "]"
-		}
-	case FormatRGBFunc:
-		rgb := fmt.Sprintf("%v, %v, %v", c.RGB[0], c.RGB[1], c.RGB[2])
-		if c.Alpha != nil {
-			rgb += fmt.Sprintf(", %s", formatAlpha(*c.Alpha))
-		}
-		prefix := "rgb"
-		if c.Alpha != nil {
-			prefix = "rgba"
-		}
-		if plain {
-			workingString = rgb
-		} else {
-			workingString = fmt.Sprintf("%s(%s)", prefix, rgb)
 		}
 	case FormatAnsi:
 		if c.Alpha != nil {

--- a/config.go
+++ b/config.go
@@ -17,14 +17,12 @@ const (
 	FormatHex ColorFormat = "hex"
 
 	FormatHSL      ColorFormat = "hsl"
-	FormatHSLArray ColorFormat = "hsl-array"
 	FormatHSLCSS   ColorFormat = "hsl-css"
-	FormatHSLFunc  ColorFormat = "hsl-function"
+	FormatHSLArray ColorFormat = "hsl-array"
 
 	FormatRGB      ColorFormat = "rgb"
-	FormatRGBArray ColorFormat = "rgb-array"
 	FormatRGBCSS   ColorFormat = "rgb-css"
-	FormatRGBFunc  ColorFormat = "rgb-function"
+	FormatRGBArray ColorFormat = "rgb-array"
 
 	FormatAnsi ColorFormat = "ansi"
 )

--- a/main.go
+++ b/main.go
@@ -17,17 +17,21 @@ type format struct {
 
 var formats = [...]format{
 	{Name: "hex", Example: "#ebbcba"},
-	{Name: "hex-ns", Example: "ebbcba"},
+	{Name: "hex --plain", Example: "ebbcba"},
 
-	{Name: "hsl", Example: "2, 55%, 83%"},
-	{Name: "hsl-array", Example: "[2, 55%, 83%]"},
+	{Name: "hsl", Example: "hsl(2, 55%, 83%)"},
+	{Name: "hsl --plain", Example: "2, 55%, 83%"},
 	{Name: "hsl-css", Example: "hsl(2deg 55% 83%)"},
-	{Name: "hsl-function", Example: "hsl(2, 55%, 83%)"},
+	{Name: "hsl-css --plain", Example: "2deg 55% 83%"},
+	{Name: "hsl-array", Example: "[2, 55%, 83%]"},
+	{Name: "hsl-array --plain", Example: "2, 55%, 83%"},
 
-	{Name: "rgb", Example: "235, 188, 186"},
-	{Name: "rgb-array", Example: "[235, 188, 186]"},
+	{Name: "rgb", Example: "rgb(235, 188, 186)"},
+	{Name: "rgb --plain", Example: "235, 188, 186"},
 	{Name: "rgb-css", Example: "rgb(235 188 186)"},
-	{Name: "rgb-function", Example: "rgb(235, 188, 186)"},
+	{Name: "rgb-css --plain", Example: "235 188 186"},
+	{Name: "rgb-array", Example: "[235, 188, 186]"},
+	{Name: "rgb-array --plain", Example: "235, 188, 186"},
 
 	{Name: "ansi", Example: "235;188;186"},
 }
@@ -122,17 +126,6 @@ func main() {
 	cfg.Template = template
 	cfg.Commas = !*noCommas
 	cfg.Spaces = !*noSpaces
-
-	// Backward compatibility: hex-ns is equivalent to hex --plain
-	if cfg.Format == "hex-ns" {
-		cfg.Format = "hex"
-		cfg.Plain = true
-	}
-
-	// Backward compatibility: rgb-ansi is equivalent to ansi
-	if cfg.Format == "rgb-ansi" {
-		cfg.Format = "ansi"
-	}
 
 	if err := Build(cfg); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
BREAKING CHANGE: Format names have been simplified:
- `hex-ns` is now `hex --plain`
- `hsl-function` is now `hsl`
- `rgb-function` is now `rgb`

The previous plain `hsl` and `rgb` formats can be restored using the `--plain` flag.