### PR TITLE
fix: `-v` flag now exits after displaying version information

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,8 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Printf("bloom %s", getCurrentVersion())
+		fmt.Println("bloom ", getCurrentVersion())
+		os.Exit(0)
 	}
 
 	args := flag.Args()


### PR DESCRIPTION
also of note but not included in this PR,
the version checking doesn't work unless you're running it in the source directory.