### PR TITLE
set version during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,12 @@ jobs:
           go-version: 1.24.4
       - name: Build
         run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG_NAME#v}
           mkdir -p dist
           ext=""
           if [ "${{ matrix.os }}" = "windows" ]; then ext=".exe"; fi
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o dist/${FILENAME}${ext}
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -ldflags="-X github.com/rose-pine/rose-pine-bloom/version.Version=$VERSION" -o dist/${FILENAME}${ext}
       - name: Upload to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs.go
+++ b/docs.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/rose-pine/rose-pine-bloom/version"
 )
 
 const (
@@ -26,10 +28,9 @@ func ensureReadmeWithBuildCommand(cmd string) error {
 	}
 	contentStr := string(content)
 
-	version := getCurrentVersion()
 	versionSuffix := ""
-	if version != "" {
-		versionSuffix = "@" + version
+	if version.Version != "" {
+		versionSuffix = "@" + version.Version
 	}
 
 	section := fmt.Sprintf("%s\nThis theme was built using [rose-pine-bloom](https://github.com/rose-pine/rose-pine-bloom):\n\n```sh\n%s\n```\n\nInstall via [goblin](https://goblin.run):\n\n```sh\ncurl -sf http://goblin.run/github.com/rose-pine/rose-pine-bloom%s | sh\n```\n%s", startMarker, cmd, versionSuffix, endMarker)

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"github.com/rose-pine/rose-pine-bloom/version"
 )
 
 type format struct {
@@ -79,7 +79,7 @@ func helpText() string {
     $ bloom --format hsl --output ./themes template.json
     $ bloom --create dawn my-theme.toml
 
-`, getCurrentVersion(), formatsTable())
+`, version.Version, formatsTable())
 }
 
 func printHelp() {
@@ -114,7 +114,7 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Println("bloom ", getCurrentVersion())
+		fmt.Println("bloom ", version.Version)
 		os.Exit(0)
 	}
 
@@ -189,15 +189,4 @@ func findTemplate(args []string) (string, error) {
 	default:
 		return "", fmt.Errorf("multiple positional arguments detected, ensure all flags come before the template")
 	}
-}
-
-func getCurrentVersion() string {
-	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	version := strings.TrimSpace(string(output))
-	return version
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+var Version string = "dev"
+


### PR DESCRIPTION
I did not test the workflow. This is a suggestion how it could work.

```
» go build  -ldflags="-X github.com/rose-pine/rose-pine-bloom/version.Version=4.0.0" -o bloom
» ./bloom -version
bloom  4.0.0
```

#65 
