### PR TITLE
feat: nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bloom
 /rose-pine-bloom
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+    nix-filter,
+  }: let
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+    filter = nix-filter.lib;
+  in {
+    packages = eachSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        default = pkgs.buildGoModule {
+          pname = "rose-pine-bloom";
+          version = "0.0.0";
+
+          src = filter {
+            root = ./.;
+            include = [
+              ./go.mod
+              ./go.sum
+              ./main.go
+              ./builder
+              ./cmd
+              ./color
+              ./config
+              ./template
+              ./version
+              ./docs
+            ];
+          };
+
+          vendorHash = "sha256-NW40XkNXAYJ6Y/lPNcKDTNSGljlA9kl4FpQSVCMrfw0=";
+
+          meta.mainProgram = "rose-pine-bloom";
+        };
+        rose-pine-bloom = self.packages.${system}.default;
+      }
+    );
+
+    devShells = eachSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.go
+            pkgs.gopls
+          ];
+        };
+        bloom = pkgs.mkShell {
+          packages = [self.packages.${system}.rose-pine-bloom];
+        };
+      }
+    );
+
+    overlays.default = final: prev: {
+      rose-pine-bloom = self.packages.${final.stdenv.hostPlatform.system}.rose-pine-bloom;
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,0 @@
-{ pkgs ? import <nixpkgs> {} }:
-pkgs.mkShellNoCC {
-  packages = with pkgs; [
-    go
-    gopls
-  ];
-}


### PR DESCRIPTION
I've added a Nix flake that replaces `shell.nix` and also exposes a reproducible way for building this tool, this makes it easy for other themes that use bloom to depend on it through nix, and gives you another way to run bloom without installing, e.g. `nix run github:rose-pine/rose-pine-bloom`

I've left the version set to `0.0.0` since i don't think it's practical to keep this in sync manually, but I'm not sure what the best approach is here.

Let me know if this is something you'd want to include, I can understand maintaining this can be cumbersome, so I'm happy to help with that.

