### PR TITLE
refactor: template builder

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -6,264 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/rose-pine/rose-pine-bloom/color"
 )
 
-type Options struct {
-	Template string
-	Output   string
-	Prefix   string
-	Format   string
-	Plain    bool
-	Commas   bool
-	Spaces   bool
+type BuildOpts struct {
+	DefaultFormat color.ColorFormat
+	Prefix        rune
+	Plain         bool
+	Commas        bool
+	Spaces        bool
 }
 
-type TemplateOptions struct {
-	Input   string
-	Output  string
-	Variant string
-	Prefix  string
-	Format  string
-	Plain   bool
-	Commas  bool
-	Spaces  bool
-
-	DetectedFormat string
-	TemplatePath   string
-}
-
-const (
-	warnColor  = "\033[33m"
-	resetColor = "\033[0m"
-)
-
-var variantValueRe = regexp.MustCompile(`\$\((.*?)\|(.*?)\|(.*?)\)`)
-
-func BuildTemplate(cfg *TemplateOptions) error {
-	if err := os.MkdirAll(cfg.Output, 0755); err != nil {
-		return fmt.Errorf("create output directory: %w", err)
-	}
-
-	return createTemplates(cfg)
-}
-
-func Build(cfg *Options) error {
-	if err := os.MkdirAll(cfg.Output, 0755); err != nil {
-		return fmt.Errorf("create output directory: %w", err)
-	}
-
-	return generateThemes(cfg)
-}
-
-func generateThemes(cfg *Options) error {
-	templates, err := templateFiles(cfg.Template)
-	if err != nil {
-		return err
-	}
-
-	for _, tp := range templates {
-		content, err := os.ReadFile(tp)
-		if err != nil {
-			return err
-		}
-
-		hasAccent := strings.Contains(string(content), cfg.Prefix+"accent")
-
-		for _, v := range color.Variants {
-			if hasAccent {
-				for _, accent := range color.Accents {
-					if err := generateThemeFile(cfg, tp, content, v, accent); err != nil {
-						return err
-					}
-				}
-			} else {
-				if err := generateThemeFile(cfg, tp, content, v, ""); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func generateThemeFile(cfg *Options, templatePath string, content []byte, variant color.VariantMeta, accent string) error {
-	result := processTemplate(string(content), cfg, variant, accent)
-
-	if filepath.Ext(templatePath) == ".json" {
-		var buf bytes.Buffer
-		if err := json.Indent(&buf, []byte(result), "", "  "); err != nil {
-			return err
-		}
-		result = buf.String()
-	}
-
-	outputPath := buildOutputPath(cfg, templatePath, variant, accent)
-	return writeFile(outputPath, []byte(result))
-}
-
-func detectFormatOptions(content string, variant color.VariantMeta) (color.ColorFormat, bool, bool, bool) {
-	bestFmt := color.ColorFormat("hex")
-	bestPlain, bestCommas, bestSpaces := false, true, true
-	bestCount := 0
-
-	for _, f := range color.AllFormats {
-		fmt := color.ColorFormat(f)
-		for _, plain := range []bool{false, true} {
-			for _, spaces := range []bool{true, false} {
-				for _, commas := range []bool{true, false} {
-					count := 0
-					for _, c := range variant.Colors {
-						val := color.FormatColor(c, fmt, plain, commas, spaces)
-						if strings.Contains(content, val) {
-							count++
-						}
-					}
-					if count > bestCount {
-						bestFmt, bestPlain, bestCommas, bestSpaces = fmt, plain, commas, spaces
-						bestCount = count
-					}
-				}
-			}
-		}
-	}
-
-	return bestFmt, bestPlain, bestCommas, bestSpaces
-}
-
-func createTemplates(cfg *TemplateOptions) error {
-	files, err := templateFiles(cfg.Input)
-	if err != nil {
-		return err
-	}
-
-	variant := color.MainVariantMeta
-	switch cfg.Variant {
-	case "moon":
-		variant = color.MoonVariantMeta
-	case "dawn":
-		variant = color.DawnVariantMeta
-	}
-
-	for _, file := range files {
-		raw, err := os.ReadFile(file)
-		if err != nil {
-			return err
-		}
-
-		content := string(raw)
-
-		formatStr, plain, commas, spaces := cfg.Format, cfg.Plain, cfg.Commas, cfg.Spaces
-		if formatStr == "" {
-			var df color.ColorFormat
-			df, plain, commas, spaces = detectFormatOptions(content, variant)
-			formatStr = string(df)
-		}
-
-		data := []string{}
-
-		for name, c := range variant.Colors {
-			val := color.FormatColor(c, color.ColorFormat(formatStr), plain, commas, spaces)
-			data = append(data, val, cfg.Prefix+name)
-		}
-
-		data = append(data, variant.Id, cfg.Prefix+"id")
-		data = append(data, variant.Name, cfg.Prefix+"name")
-		data = append(data, variant.Description, cfg.Prefix+"description")
-
-		result := strings.NewReplacer(data...).Replace(content)
-
-		if content == result {
-			fmt.Printf("%sNo matches for format %q. Available formats:\n  %s%s\n", warnColor, formatStr, strings.Join(color.AllFormats, ", "), resetColor)
-		}
-
-		ext := filepath.Ext(file)
-		outputFile := "template" + ext
-		outputPath := filepath.Join(cfg.Output, outputFile)
-
-		cfg.DetectedFormat = formatStr
-		cfg.TemplatePath = outputPath
-
-		if err := writeFile(outputPath, []byte(result)); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func processTemplate(content string, cfg *Options, variant color.VariantMeta, accent string) string {
-	data := []string{}
-
-	data = append(data, cfg.Prefix+"id", variant.Id)
-	data = append(data, cfg.Prefix+"name", variant.Name)
-	data = append(data, cfg.Prefix+"type", variant.Appearance)
-	data = append(data, cfg.Prefix+"appearance", variant.Appearance)
-	data = append(data, cfg.Prefix+"description", variant.Description)
-
-	if accent != "" {
-		data = append(data, cfg.Prefix+"accentname", accent)
-
-		if c, ok := variant.Colors[accent]; ok {
-			accentColor := color.FormatColor(c, color.ColorFormat(cfg.Format), cfg.Plain, cfg.Commas, cfg.Spaces)
-			data = append(data, cfg.Prefix+"accent", accentColor)
-			if c.On != "" {
-				if oc, ok := variant.Colors[c.On]; ok {
-					onAccent := color.FormatColor(oc, color.ColorFormat(cfg.Format), cfg.Plain, cfg.Commas, cfg.Spaces)
-					data = append(data, cfg.Prefix+"onaccent", onAccent)
-				}
-			}
-		}
-	}
-
-	for name, c := range variant.Colors {
-		varName := cfg.Prefix + name
-
-		alphaRe := regexp.MustCompile(regexp.QuoteMeta(varName) + `/(\d+)`)
-		matches := alphaRe.FindAllStringSubmatch(content, -1)
-		seen := make(map[string]bool)
-		for _, m := range matches {
-			if seen[m[0]] {
-				continue
-			}
-			seen[m[0]] = true
-			alpha, _ := strconv.ParseFloat(m[1], 64)
-			tmp := *c
-			a := alpha / 100
-			tmp.Alpha = &a
-			data = append(data, m[0], color.FormatColor(&tmp, color.ColorFormat(cfg.Format), cfg.Plain, cfg.Commas, cfg.Spaces))
-		}
-
-		data = append(data, varName, color.FormatColor(c, color.ColorFormat(cfg.Format), cfg.Plain, cfg.Commas, cfg.Spaces))
-	}
-
-	result := strings.NewReplacer(data...).Replace(content)
-
-	result = variantValueRe.ReplaceAllStringFunc(result, func(match string) string {
-		parts := variantValueRe.FindStringSubmatch(match)
-		if len(parts) != 4 {
-			return match
-		}
-		switch variant.Id {
-		case "rose-pine":
-			return parts[1]
-		case "rose-pine-moon":
-			return parts[2]
-		case "rose-pine-dawn":
-			return parts[3]
-		}
-		return match
-	})
-
-	return result
-}
-
-func templateFiles(path string) ([]string, error) {
+func DiscoverTemplates(path string) ([]string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -286,26 +41,102 @@ func templateFiles(path string) ([]string, error) {
 	return files, err
 }
 
-func writeFile(outputPath string, content []byte) error {
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(outputPath, content, 0644)
-}
-
-func buildOutputPath(cfg *Options, templatePath string, variant color.VariantMeta, accent string) string {
+func buildOutPath(templatePath string, outputPath string, variant color.VariantMeta, accent string) string {
 	ext := filepath.Ext(templatePath)
 
-	if info, err := os.Stat(cfg.Template); err == nil && info.IsDir() {
-		ext := filepath.Ext(templatePath)
+	if info, err := os.Stat(templatePath); err == nil && info.IsDir() {
 		if accent != "" {
-			return filepath.Join(cfg.Output, variant.Id+"-"+accent+ext)
+			return filepath.Join(outputPath, variant.Id+"-"+accent+ext)
 		}
-		return filepath.Join(cfg.Output, variant.Id+ext)
+		return filepath.Join(outputPath, variant.Id+ext)
 	}
 
 	if accent != "" {
-		return filepath.Join(cfg.Output, variant.Id, variant.Id+"-"+accent+ext)
+		return filepath.Join(outputPath, variant.Id, variant.Id+"-"+accent+ext)
 	}
-	return filepath.Join(cfg.Output, variant.Id+ext)
+	return filepath.Join(outputPath, variant.Id+ext)
+}
+
+func writeFile(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func writeTemplateFile(path string, content string) error {
+	result, err := postProcessTemplate(path, content)
+	if err != nil {
+		return fmt.Errorf("post-processing hook failed: %w", err)
+	}
+
+	return writeFile(path, ([]byte)(result))
+}
+
+func hasAccentCapture(captures []Capture) bool {
+	for _, capture := range captures {
+		if rc, ok := capture.(RoleCapture); ok && rc.role == "accent" {
+			return true
+		}
+	}
+	return false
+}
+
+func postProcessTemplate(templatePath string, content string) (string, error) {
+	result := content
+
+	if filepath.Ext(templatePath) == ".json" {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, []byte(result), "", "  "); err != nil {
+			return "", fmt.Errorf("failed to format template output as JSON")
+		}
+		result = buf.String()
+	}
+
+	return result, nil
+}
+
+func Build(templatePath string, outPath string, opts *BuildOpts) error {
+	scannerOpts := ScannerOpts{Prefix: opts.Prefix}
+	templates, err := DiscoverTemplates(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to discover templates: %w", err)
+	}
+
+	for _, templatePath := range templates {
+		bytes, err := os.ReadFile(templatePath)
+		if err != nil {
+			return fmt.Errorf("failed to read template at `%s`: %w", templatePath, err)
+		}
+		content := string(bytes)
+		captures, err := Scan(content, scannerOpts)
+		if err != nil {
+			return fmt.Errorf("failed to scan template: %w", err)
+		}
+
+		for _, variant := range color.Variants {
+			if hasAccentCapture(captures) {
+				for _, accent := range color.Accents {
+					result, err := substituteCaptures(content, captures, variant, opts, accent)
+					if err != nil {
+						return err
+					}
+					if err := writeTemplateFile(buildOutPath(templatePath, outPath, variant, accent), result); err != nil {
+						return err
+					}
+				}
+			} else {
+				result, err := substituteCaptures(content, captures, variant, opts, "")
+				if err != nil {
+					return err
+				}
+
+				if err := writeTemplateFile(buildOutPath(templatePath, outPath, variant, ""), result); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/rose-pine/rose-pine-bloom/color"
@@ -17,22 +16,19 @@ func setupTest(t *testing.T) string {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
+		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Fatal(err)
 		}
 	})
 	return tmpDir
 }
 
-func buildFromTemplate(t *testing.T, template string, cfg *Options) {
-	templatePath := filepath.Join(cfg.Output, "template.json")
+func buildFromTemplate(t *testing.T, template string, templatePath string, outPath string, opts *BuildOpts) {
+	t.Helper()
 	if err := os.WriteFile(templatePath, []byte(template), 0644); err != nil {
 		t.Fatal(err)
 	}
-	cfg.Template = templatePath
-
-	if err := Build(cfg); err != nil {
+	if err := Build(templatePath, outPath, opts); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -43,7 +39,6 @@ func readAndParseJSON(t *testing.T, path string) map[string]any {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	var result map[string]any
 	if err := json.Unmarshal(content, &result); err != nil {
 		t.Fatal(err)
@@ -58,26 +53,12 @@ func assertJSONField(t *testing.T, result map[string]any, field, want string) {
 	}
 }
 
-// testConfig provides standard config
-var testConfig = Options{
-	Template: "",
-	Output:   "",
-	Prefix:   "$",
-	Format:   "hex",
-	Plain:    false,
-	Commas:   true,
-	Spaces:   true,
-}
-
-var testBuildTemplateConfig = TemplateOptions{
-	Input:   "",
-	Output:  "",
-	Variant: "moon",
-	Prefix:  "$",
-	Format:  "hex",
-	Plain:   false,
-	Commas:  true,
-	Spaces:  true,
+var testOpts = BuildOpts{
+	DefaultFormat: color.FormatHex,
+	Prefix:        '$',
+	Plain:         false,
+	Commas:        true,
+	Spaces:        true,
 }
 
 // testColor provides a standard color
@@ -86,7 +67,6 @@ var testColor = &color.Color{
 	RGB: color.RGB{R: 235, G: 188, B: 186},
 }
 
-// testTemplate provides a standard template
 const testTemplate = `{
     "id": "$id",
     "name": "$name",
@@ -239,20 +219,12 @@ func TestAlphaFormatting(t *testing.T) {
 }
 
 func TestAlphaVariableFormats(t *testing.T) {
-	tmpDir := setupTest(t)
-
-	templateContent := `{
-        "base": "$base",
-        "base25": "$base/25",
-        "base50": "$base/50"
-    }`
-
 	tests := []struct {
-		format string
+		format color.ColorFormat
 		want   map[string]string
 	}{
 		{
-			format: "hex",
+			format: color.FormatHex,
 			want: map[string]string{
 				"base":   "#191724",
 				"base25": "#19172440",
@@ -260,7 +232,7 @@ func TestAlphaVariableFormats(t *testing.T) {
 			},
 		},
 		{
-			format: "hsl",
+			format: color.FormatHSL,
 			want: map[string]string{
 				"base":   "hsl(249, 22%, 12%)",
 				"base25": "hsla(249, 22%, 12%, 0.25)",
@@ -268,7 +240,7 @@ func TestAlphaVariableFormats(t *testing.T) {
 			},
 		},
 		{
-			format: "hsl-css",
+			format: color.FormatHSLCSS,
 			want: map[string]string{
 				"base":   "hsl(249deg 22% 12%)",
 				"base25": "hsl(249deg 22% 12% / 0.25)",
@@ -276,7 +248,7 @@ func TestAlphaVariableFormats(t *testing.T) {
 			},
 		},
 		{
-			format: "rgb",
+			format: color.FormatRGB,
 			want: map[string]string{
 				"base":   "rgb(25, 23, 36)",
 				"base25": "rgba(25, 23, 36, 0.25)",
@@ -284,7 +256,7 @@ func TestAlphaVariableFormats(t *testing.T) {
 			},
 		},
 		{
-			format: "rgb-css",
+			format: color.FormatRGBCSS,
 			want: map[string]string{
 				"base":   "rgb(25 23 36)",
 				"base25": "rgb(25 23 36 / 0.25)",
@@ -293,16 +265,22 @@ func TestAlphaVariableFormats(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.format, func(t *testing.T) {
-			cfg := testConfig
-			cfg.Output = tmpDir
-			cfg.Format = tt.format
+	templateContent := `{
+        "base": "$base",
+        "base25": "$base/25",
+        "base50": "$base/50"
+    }`
 
-			buildFromTemplate(t, templateContent, &cfg)
+	for _, tt := range tests {
+		t.Run(string(tt.format), func(t *testing.T) {
+			tmpDir := setupTest(t)
+			opts := testOpts
+			opts.DefaultFormat = tt.format
+
+			templatePath := filepath.Join(tmpDir, "template.json")
+			buildFromTemplate(t, templateContent, templatePath, tmpDir, &opts)
 
 			result := readAndParseJSON(t, filepath.Join(tmpDir, "rose-pine.json"))
-
 			for field, want := range tt.want {
 				assertJSONField(t, result, field, want)
 			}
@@ -313,11 +291,11 @@ func TestAlphaVariableFormats(t *testing.T) {
 func TestVariantGeneration(t *testing.T) {
 	tmpDir := setupTest(t)
 
-	cfg := testConfig
-	cfg.Output = tmpDir
-	cfg.Spaces = false
+	opts := testOpts
+	opts.Spaces = false
 
-	buildFromTemplate(t, testTemplate, &cfg)
+	templatePath := filepath.Join(tmpDir, "template.json")
+	buildFromTemplate(t, testTemplate, templatePath, tmpDir, &opts)
 
 	for _, v := range testVariants {
 		t.Run(v.filename, func(t *testing.T) {
@@ -338,19 +316,13 @@ func TestVariantGeneration(t *testing.T) {
 
 func BenchmarkBuild(b *testing.B) {
 	testContent := ""
-	fileSizeMultiplier := 20 // Adjust this value to increase/decrease the size of the template
+	fileSizeMultiplier := 20
 	for range fileSizeMultiplier {
 		testContent += testTemplate + "\n"
 	}
+	captures, _ := Scan(testContent, ScannerOpts{Prefix: testOpts.Prefix})
 	for b.Loop() {
-		processTemplate(testContent, &testConfig, color.MainVariantMeta, "")
-	}
-}
-
-func BenchmarkDetectFormatOptions(b *testing.B) {
-	content := `{"base": "#191724", "love": "#eb6f92"}`
-	for b.Loop() {
-		detectFormatOptions(content, color.MainVariantMeta)
+		_, _ = substituteCaptures(testContent, captures, color.MainVariantMeta, &testOpts, "")
 	}
 }
 
@@ -363,10 +335,8 @@ func TestVariantSpecificValues(t *testing.T) {
         "mood": "$(Dark|Dim|Light)"
     }`
 
-	cfg := testConfig
-	cfg.Output = tmpDir
-
-	buildFromTemplate(t, templateContent, &cfg)
+	templatePath := filepath.Join(tmpDir, "template.json")
+	buildFromTemplate(t, templateContent, templatePath, tmpDir, &testOpts)
 
 	tests := []struct {
 		variant string
@@ -396,13 +366,11 @@ func TestAccents(t *testing.T) {
 	templateContent := `{
         "accentname": "$accentname",
         "accent": "$accent",
-		"onaccent": "$onaccent"
+        "onaccent": "$onaccent"
     }`
 
-	cfg := testConfig
-	cfg.Output = tmpDir
-
-	buildFromTemplate(t, templateContent, &cfg)
+	templatePath := filepath.Join(tmpDir, "template.json")
+	buildFromTemplate(t, templateContent, templatePath, tmpDir, &testOpts)
 
 	tests := []struct {
 		filename   string
@@ -446,9 +414,8 @@ func TestAccents(t *testing.T) {
 func TestDirectories(t *testing.T) {
 	tmpDir := setupTest(t)
 
-	templateDir := filepath.Join(tmpDir, "template")
-	err := os.Mkdir(templateDir, 0755)
-	if err != nil {
+	templateDir := filepath.Join(tmpDir, "templates")
+	if err := os.Mkdir(templateDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	templatePath := filepath.Join(templateDir, "template.json")
@@ -456,17 +423,14 @@ func TestDirectories(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := testConfig
-	cfg.Output = tmpDir
-	cfg.Template = templateDir
-
-	if err := Build(&cfg); err != nil {
+	outDir := filepath.Join(tmpDir, "out")
+	if err := Build(templateDir, outDir, &testOpts); err != nil {
 		t.Fatal(err)
 	}
 
 	for _, variant := range testVariants {
 		t.Run(variant.filename, func(t *testing.T) {
-			result := readAndParseJSON(t, filepath.Join(tmpDir, variant.filename))
+			result := readAndParseJSON(t, filepath.Join(outDir, variant.filename))
 
 			assertJSONField(t, result, "id", variant.id)
 			assertJSONField(t, result, "name", variant.name)
@@ -480,244 +444,79 @@ func TestDirectories(t *testing.T) {
 	}
 }
 
-func TestDetectFormatOptions(t *testing.T) {
-	colors := func(base, love string) string {
-		return fmt.Sprintf(`{"base": "%s", "love": "%s"}`, base, love)
-	}
-
-	tests := []struct {
-		name       string
-		content    string
-		wantFormat color.ColorFormat
-		wantPlain  bool
-		wantCommas bool
-		wantSpaces bool
-	}{
-		{
-			name:       "hex with hash",
-			content:    colors("#191724", "#eb6f92"),
-			wantFormat: color.FormatHex,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "hex plain",
-			content:    colors("191724", "eb6f92"),
-			wantFormat: color.FormatHex,
-			wantPlain:  true,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "rgb function",
-			content:    colors("rgb(25, 23, 36)", "rgb(235, 111, 146)"),
-			wantFormat: color.FormatRGB,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "rgb no spaces",
-			content:    colors("rgb(25,23,36)", "rgb(235,111,146)"),
-			wantFormat: color.FormatRGB,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: false,
-		},
-		{
-			name:       "rgb no commas",
-			content:    colors("rgb(25 23 36)", "rgb(235 111 146)"),
-			wantFormat: color.FormatRGB,
-			wantPlain:  false,
-			wantCommas: false,
-			wantSpaces: true,
-		},
-		{
-			name:       "hsl function",
-			content:    colors("hsl(249, 22%, 12%)", "hsl(343, 76%, 68%)"),
-			wantFormat: color.FormatHSL,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "hsl no spaces",
-			content:    colors("hsl(249,22%,12%)", "hsl(343,76%,68%)"),
-			wantFormat: color.FormatHSL,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: false,
-		},
-		{
-			name:       "hsl css",
-			content:    colors("hsl(249deg 22% 12%)", "hsl(343deg 76% 68%)"),
-			wantFormat: color.FormatHSLCSS,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "ansi",
-			content:    colors("25;23;36", "235;111;146"),
-			wantFormat: color.FormatAnsi,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-		{
-			name:       "fallback on no match",
-			content:    "no colors here at all",
-			wantFormat: color.FormatHex,
-			wantPlain:  false,
-			wantCommas: true,
-			wantSpaces: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotFormat, gotPlain, gotCommas, gotSpaces := detectFormatOptions(tt.content, color.MainVariantMeta)
-			if gotFormat != tt.wantFormat {
-				t.Errorf("format = %q, want %q", gotFormat, tt.wantFormat)
-			}
-			if gotPlain != tt.wantPlain {
-				t.Errorf("plain = %v, want %v", gotPlain, tt.wantPlain)
-			}
-			if gotCommas != tt.wantCommas {
-				t.Errorf("commas = %v, want %v", gotCommas, tt.wantCommas)
-			}
-			if gotSpaces != tt.wantSpaces {
-				t.Errorf("spaces = %v, want %v", gotSpaces, tt.wantSpaces)
-			}
-		})
-	}
-}
-
-func TestCreateAutoDetect(t *testing.T) {
-	tests := []struct {
-		name    string
-		variant string
-		input   string
-		format  string
-		wantVal string
-	}{
-		{
-			name:    "auto-detect hex",
-			variant: "moon",
-			input:   `"base": "#232136"`,
-			format:  "",
-			wantVal: "$base",
-		},
-		{
-			name:    "auto-detect hsl",
-			variant: "moon",
-			input:   `"base": "hsl(246, 24%, 17%)"`,
-			format:  "",
-			wantVal: "$base",
-		},
-		{
-			name:    "auto-detect rgb",
-			variant: "moon",
-			input:   `"base": "rgb(35, 33, 54)"`,
-			format:  "",
-			wantVal: "$base",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tmpDir := setupTest(t)
-
-			fileContent := "{\n  " + tt.input + "\n}"
-			filePath := filepath.Join(tmpDir, "input.json")
-			if err := os.WriteFile(filePath, []byte(fileContent), 0644); err != nil {
-				t.Fatal(err)
-			}
-
-			cfg := testBuildTemplateConfig
-			cfg.Output = tmpDir
-			cfg.Input = filePath
-			cfg.Format = tt.format
-			cfg.Variant = tt.variant
-
-			if err := BuildTemplate(&cfg); err != nil {
-				t.Fatal(err)
-			}
-
-			content, err := os.ReadFile(filepath.Join(tmpDir, "template.json"))
-			if err != nil {
-				t.Fatalf("Failed to read generated file: %v", err)
-			}
-			if !strings.Contains(string(content), tt.wantVal) {
-				t.Errorf("generated template should contain %q, got:\n%s", tt.wantVal, string(content))
-			}
-		})
-	}
-}
-
-func TestCreate(t *testing.T) {
-	tmpDir := setupTest(t)
-
-	fileContent := `{
-  "base": "#232136",
-  "surface": "#2a273f",
-  "overlay": "#393552",
-  "muted": "#6e6a86",
-  "subtle": "#908caa",
-  "text": "#e0def4",
-  "love": "#eb6f92",
-  "gold": "#f6c177",
-  "rose": "#ea9a97",
-  "pine": "#3e8fb0",
-  "foam": "#9ccfd8",
-  "iris": "#c4a7e7",
-  "main-id": "rose-pine",
-  "id": "rose-pine-moon",
-  "name": "Rosé Pine Moon",
-  "description": "All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
-  "dawn-name": "Rosé Pine Dawn"
-}`
-	expected := `{
-  "base": "$base",
-  "surface": "$surface",
-  "overlay": "$overlay",
-  "muted": "$muted",
-  "subtle": "$subtle",
-  "text": "$text",
-  "love": "$love",
-  "gold": "$gold",
-  "rose": "$rose",
-  "pine": "$pine",
-  "foam": "$foam",
-  "iris": "$iris",
-  "main-id": "rose-pine",
-  "id": "$id",
-  "name": "$name",
-  "description": "$description",
-  "dawn-name": "Rosé Pine Dawn"
-}`
-
-	filePath := filepath.Join(tmpDir, "input.json")
-	if err := os.WriteFile(filePath, []byte(fileContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := testBuildTemplateConfig
-	cfg.Output = tmpDir
-	cfg.Input = filePath
-
-	if err := BuildTemplate(&cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("template.json", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(tmpDir, "template.json"))
-		if err != nil {
-			t.Fatalf("Failed to read generated file: %v", err)
+func TestDiscoverTemplates(t *testing.T) {
+	t.Run("single file", func(t *testing.T) {
+		tmpDir := setupTest(t)
+		path := filepath.Join(tmpDir, "template.json")
+		if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
 		}
-		if string(content) != expected {
-			t.Errorf("want %s\n\n got %s", expected, string(content))
+		files, err := DiscoverTemplates(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 1 || files[0] != path {
+			t.Errorf("got %v, want [%s]", files, path)
 		}
 	})
+
+	t.Run("directory", func(t *testing.T) {
+		tmpDir := setupTest(t)
+		for _, name := range []string{"a.json", "b.json", "c.json"} {
+			p := filepath.Join(tmpDir, name)
+			if err := os.WriteFile(p, []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		files, err := DiscoverTemplates(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 3 {
+			t.Errorf("got %d files, want 3", len(files))
+		}
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		_, err := DiscoverTemplates("/nonexistent/path")
+		if err == nil {
+			t.Error("expected error for nonexistent path, got nil")
+		}
+	})
+}
+
+func TestBuildOutPath(t *testing.T) {
+	variant := color.MainVariantMeta // rose-pine
+
+	tests := []struct {
+		name         string
+		templatePath string
+		outputPath   string
+		accent       string
+		want         string
+	}{
+		{
+			name:         "no accent",
+			templatePath: "template.json",
+			outputPath:   "out",
+			accent:       "",
+			want:         fmt.Sprintf("out/%s.json", variant.Id),
+		},
+		{
+			name:         "with accent",
+			templatePath: "template.json",
+			outputPath:   "out",
+			accent:       "love",
+			want:         fmt.Sprintf("out/%s/%s-love.json", variant.Id, variant.Id),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildOutPath(tt.templatePath, tt.outputPath, variant, tt.accent)
+			if got != tt.want {
+				t.Errorf("buildOutPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/builder/scan.go
+++ b/builder/scan.go
@@ -1,0 +1,261 @@
+package builder
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+var roleKeys = []string{
+	"base", "surface", "overlay", "muted", "subtle",
+	"text", "love", "gold", "rose", "pine", "foam",
+	"iris", "highlightLow", "highlightMed", "highlightHigh",
+	"accent", "onaccent",
+}
+
+var metaKeys = []string{
+	"id", "name", "appearance", "type", "description", "accentname",
+}
+
+type ScannerOpts struct {
+	Prefix rune
+}
+
+type Capture interface {
+	captureSpan() span
+}
+
+type span struct {
+	Start  uint
+	Length uint
+}
+
+type variantArm struct {
+	content  string
+	captures []Capture
+}
+
+type (
+	RoleCapture struct {
+		span  span
+		role  string
+		alpha *float64
+	}
+	MetaCapture    struct{ span }
+	VariantCapture struct {
+		span             span
+		main, moon, dawn variantArm
+	}
+	TextCapture struct{ span }
+)
+
+func (c RoleCapture) captureSpan() span    { return c.span }
+func (c MetaCapture) captureSpan() span    { return c.span }
+func (c VariantCapture) captureSpan() span { return c.span }
+func (c TextCapture) captureSpan() span    { return c.span }
+
+func Span(c Capture) (start, length uint) {
+	s := c.captureSpan()
+	return s.Start, s.Length
+}
+
+func isAsciiDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+type Scanner struct {
+	Content     string
+	Opts        ScannerOpts
+	pos         uint
+}
+
+func (s *Scanner) curr() (byte, bool) {
+	if int(s.pos) < len(s.Content) {
+		return s.Content[s.pos], true
+	}
+	return 0, false
+}
+
+func (s *Scanner) peek() (byte, bool) {
+	idx := int(s.pos + 1)
+	if idx < len(s.Content) {
+		return s.Content[idx], true
+	}
+	return 0, false
+}
+
+func (s *Scanner) remaining() string {
+	return s.Content[s.pos:]
+}
+
+func (s *Scanner) advanceN(n int) {
+	if int(s.pos)+n > len(s.Content) {
+		return
+	}
+	s.pos += uint(n)
+}
+
+func (s *Scanner) advance() {
+	if int(s.pos) >= len(s.Content) {
+		return
+	}
+	s.pos++
+}
+
+func (s *Scanner) advanceToEOF() {
+	s.pos = uint(len(s.Content))
+}
+
+func (s *Scanner) scanUntil(ch byte) bool {
+	idx := strings.IndexByte(s.remaining(), ch)
+	if idx != -1 {
+		s.advanceN(idx)
+		return true
+	}
+	return false
+}
+
+func (s *Scanner) advanceToPrefix() bool {
+	return s.scanUntil(byte(s.Opts.Prefix))
+}
+
+func (s *Scanner) scanKey(keys []string) (string, bool) {
+	src := s.remaining()
+	for _, key := range keys {
+		if strings.HasPrefix(src, key) {
+			next := src[len(key):]
+			if len(next) > 0 && (unicode.IsLetter(rune(next[0])) || unicode.IsDigit(rune(next[0]))) {
+				continue
+			}
+			s.advanceN(len(key))
+			return key, true
+		}
+	}
+	return "", false
+}
+
+func (s *Scanner) scanVariantCapture(outerStartPos uint) (VariantCapture, error) {
+	s.advance()
+	start := s.pos
+	s.scanUntil(')')
+	content := s.Content[start:s.pos]
+	parts := strings.SplitN(content, "|", 3)
+	s.advance()
+
+	mainCaptures, err := Scan(parts[0], s.Opts)
+	if err != nil {
+		return VariantCapture{}, err
+	}
+
+	moonCaptures, err := Scan(parts[1], s.Opts)
+	if err != nil {
+		return VariantCapture{}, err
+	}
+
+	dawnCaptures, err := Scan(parts[2], s.Opts)
+	if err != nil {
+		return VariantCapture{}, err
+	}
+
+	return VariantCapture{
+		span: span{outerStartPos, s.pos - outerStartPos},
+		main: variantArm{content: parts[0], captures: mainCaptures},
+		moon: variantArm{content: parts[1], captures: moonCaptures},
+		dawn: variantArm{content: parts[2], captures: dawnCaptures},
+	}, nil
+}
+
+func (s *Scanner) scanRoleCapture(start uint, role string) (RoleCapture, error) {
+	var alpha *float64
+	if curr, _ := s.curr(); curr == '/' {
+		if peeked, _ := s.peek(); isAsciiDigit(peeked) {
+			s.advance()
+			alphaStart := s.pos
+			for {
+				if curr, _ := s.curr(); isAsciiDigit(curr) {
+					s.advance()
+				} else {
+					break
+				}
+			}
+			parsed, err := strconv.ParseInt(s.Content[alphaStart:s.pos], 10, 32)
+			if err == nil {
+				value := float64(parsed) / 100
+				alpha = &value
+			}
+		}
+	}
+	return RoleCapture{
+		span:  span{start, s.pos - start},
+		role:  role,
+		alpha: alpha,
+	}, nil
+}
+
+func (s *Scanner) scanCapture() (Capture, bool, error) {
+	start := s.pos
+
+	if curr, _ := s.curr(); curr == byte(s.Opts.Prefix) {
+		s.advance()
+
+		if curr, _ := s.curr(); curr == '(' {
+			vc, err := s.scanVariantCapture(start)
+			return vc, true, err
+		}
+
+		if _, found := s.scanKey(metaKeys); found {
+			return MetaCapture{span{start, s.pos - start}}, true, nil
+		}
+
+		if role, found := s.scanKey(roleKeys); found {
+			rc, err := s.scanRoleCapture(start, role)
+			return rc, true, err
+		}
+
+		unknown := strings.IndexFunc(s.remaining(), func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		})
+		var key string
+		if unknown == -1 {
+			key = s.remaining()
+		} else {
+			key = s.remaining()[:unknown]
+		}
+		return nil, false, fmt.Errorf("unknown variable %c%s", s.Opts.Prefix, key)
+
+	} else {
+		if !s.advanceToPrefix() {
+			s.advanceToEOF()
+		}
+		if length := s.pos - start; length > 0 {
+			return TextCapture{span{start, length}}, true, nil
+		}
+	}
+
+	return nil, false, nil
+}
+
+func (s *Scanner) scanCaptures() ([]Capture, error) {
+	prefixCount := strings.Count(s.Content, string(s.Opts.Prefix))
+	captures := make([]Capture, 0, prefixCount)
+	for {
+		capture, found, err := s.scanCapture()
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			break
+		}
+		captures = append(captures, capture)
+	}
+	return captures, nil
+}
+
+func Scan(content string, opts ScannerOpts) ([]Capture, error) {
+	scanner := Scanner{
+		Content: content,
+		Opts:    opts,
+	}
+	return scanner.scanCaptures()
+}

--- a/builder/substitute.go
+++ b/builder/substitute.go
@@ -1,0 +1,107 @@
+package builder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rose-pine/rose-pine-bloom/color"
+)
+
+func substituteCaptures(content string, captures []Capture, variant color.VariantMeta, opts *BuildOpts, accentName string) (string, error) {
+	var palette color.Palette
+	var buf strings.Builder
+
+	buf.Grow(len(content))
+
+	switch variant.Id {
+	case "rose-pine":
+		palette = color.MainPalette
+	case "rose-pine-moon":
+		palette = color.MoonPalette
+	case "rose-pine-dawn":
+		palette = color.DawnPalette
+	default:
+		return "", fmt.Errorf("unknown variant `%s`", variant.Id)
+	}
+
+	for _, capture := range captures {
+		start, length := Span(capture)
+		text := content[start : start+length]
+
+		switch c := capture.(type) {
+		case RoleCapture:
+			var clr *color.Color
+
+			if c.role == "accent" || c.role == "onaccent" {
+				accentColor, ok := variant.Colors[accentName]
+				if !ok {
+					return "", fmt.Errorf("unknown accent color `%s`", accentName)
+				}
+
+				switch c.role {
+				case "accent":
+					clr = accentColor
+
+				case "onaccent":
+					if accentColor.On == "" {
+						return "", fmt.Errorf("accent color `%s` does not support onaccent", accentColor.On)
+					}
+					if onAccentColor, ok := variant.Colors[accentColor.On]; ok {
+						clr = onAccentColor
+					} else {
+						return "", fmt.Errorf("invalid role value `%s` for onaccent", accentColor.On)
+					}
+				}
+			} else {
+				clr = palette[c.role]
+			}
+
+			if clr == nil {
+				return "", fmt.Errorf("no such role: `%s`", c.role)
+			}
+			withAlpha := clr.WithAlpha(c.alpha)
+			clr = &withAlpha
+
+			formatted := color.FormatColor(clr, opts.DefaultFormat, opts.Plain, opts.Commas, opts.Spaces)
+			buf.WriteString(formatted)
+
+		case MetaCapture:
+			switch text[1:] {
+			case "id":
+				buf.WriteString(variant.Id)
+			case "name":
+				buf.WriteString(variant.Name)
+			case "appearance":
+				buf.WriteString(variant.Appearance)
+			case "type":
+				buf.WriteString(variant.Appearance)
+			case "description":
+				buf.WriteString(variant.Description)
+			case "accentname":
+				buf.WriteString(accentName)
+			}
+
+		case VariantCapture:
+			var inner variantArm
+			switch variant.Id {
+			case "rose-pine":
+				inner = c.main
+			case "rose-pine-moon":
+				inner = c.moon
+			case "rose-pine-dawn":
+				inner = c.dawn
+			}
+			output, err := substituteCaptures(inner.content, inner.captures, variant, opts, accentName)
+			if err != nil {
+				return "", err
+			}
+
+			buf.WriteString(output)
+
+		case TextCapture:
+			buf.WriteString(text)
+		}
+	}
+
+	return buf.String(), nil
+}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -11,12 +11,12 @@ import (
 )
 
 var (
-	outputDir string
-	prefix    string
-	format    string
-	plain     bool
-	noCommas  bool
-	noSpaces  bool
+	outDir   string
+	prefix   string
+	format   string
+	plain    bool
+	noCommas bool
+	noSpaces bool
 )
 
 var buildCmd = &cobra.Command{
@@ -31,27 +31,31 @@ var buildCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if len(prefix) != 1 {
+			fmt.Fprintf(os.Stderr, "invalid prefix, must be exactly one character long\n")
+			os.Exit(1)
+		}
+
 		fmt.Printf("Building themes from %s...\n", template)
 
-		err := builder.Build(&builder.Options{
-			Template: template,
-			Output:   outputDir,
-			Prefix:   prefix,
-			Format:   format,
-			Plain:    plain,
-			Commas:   !noCommas,
-			Spaces:   !noSpaces,
-		})
+		opts := builder.BuildOpts{
+			Prefix:        rune(prefix[0]),
+			DefaultFormat: color.ColorFormat(format),
+			Plain:         plain,
+			Commas:        !noCommas,
+			Spaces:        !noSpaces,
+		}
+		err := builder.Build(template, outDir, &opts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error building themes: %v\n", err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Themes generated in %s\n", outputDir)
+		fmt.Printf("Themes generated in %s\n", outDir)
 
 		cmdLine := "bloom build " + template
-		cmdLine += " --output " + outputDir
-		cmdLine += " --prefix " + prefix
+		cmdLine += " --output " + outDir
+		cmdLine += " --prefix " + string(prefix)
 		cmdLine += " --format " + format
 		if plain {
 			cmdLine += " --plain"
@@ -72,7 +76,7 @@ var buildCmd = &cobra.Command{
 }
 
 func init() {
-	buildCmd.Flags().StringVarP(&outputDir, "output", "o", "dist", "output directory")
+	buildCmd.Flags().StringVarP(&outDir, "output", "o", "dist", "output directory")
 	buildCmd.Flags().StringVarP(&prefix, "prefix", "p", "$", "variable prefix")
 	buildCmd.Flags().StringVarP(&format, "format", "f", "hex", "hex, hsl, hsl-css, hsl-array, rgb, rgb-css, rgb-array, ansi")
 	buildCmd.Flags().BoolVar(&plain, "plain", false, "strip wrappers (#, rgb(), hsl(), brackets) from output")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rose-pine/rose-pine-bloom/builder"
+	"github.com/rose-pine/rose-pine-bloom/derive"
 	"github.com/spf13/cobra"
 )
 
@@ -33,13 +33,13 @@ var initCmd = &cobra.Command{
 		themeFile := args[0]
 		fmt.Printf("Creating template from %s...\n", themeFile)
 
-		opts := &builder.TemplateOptions{
+		opts := &derive.DeriveOpts{
 			Input:   themeFile,
 			Output:  output,
 			Variant: variant,
 			Prefix:  prefix,
 		}
-		if err := builder.BuildTemplate(opts); err != nil {
+		if err := derive.DeriveTemplate(opts); err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating template: %v\n", err)
 			os.Exit(1)
 		}

--- a/color/format.go
+++ b/color/format.go
@@ -21,6 +21,12 @@ type Color struct {
 	On    string   `json:"on,omitempty"`
 }
 
+func (c *Color) WithAlpha(alpha *float64) Color {
+	copied := *c
+	copied.Alpha = alpha
+	return copied
+}
+
 const hex = "0123456789abcdef"
 
 func hexComponent(c uint8) (byte, byte) {

--- a/derive/derive.go
+++ b/derive/derive.go
@@ -1,0 +1,135 @@
+package derive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rose-pine/rose-pine-bloom/builder"
+	"github.com/rose-pine/rose-pine-bloom/color"
+)
+
+type DeriveOpts struct {
+	Input   string
+	Output  string
+	Variant string
+	Prefix  string
+	Format  string
+	Plain   bool
+	Commas  bool
+	Spaces  bool
+
+	DetectedFormat string
+	TemplatePath   string
+}
+
+const (
+	warnColor  = "\033[33m"
+	resetColor = "\033[0m"
+)
+
+func DeriveTemplate(cfg *DeriveOpts) error {
+	if err := os.MkdirAll(cfg.Output, 0755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	return createTemplates(cfg)
+}
+
+func detectFormatOptions(content string, variant color.VariantMeta) (color.ColorFormat, bool, bool, bool) {
+	bestFmt := color.ColorFormat("hex")
+	bestPlain, bestCommas, bestSpaces := false, true, true
+	bestCount := 0
+
+	for _, f := range color.AllFormats {
+		fmt := color.ColorFormat(f)
+		for _, plain := range []bool{false, true} {
+			for _, spaces := range []bool{true, false} {
+				for _, commas := range []bool{true, false} {
+					count := 0
+					for _, c := range variant.Colors {
+						val := color.FormatColor(c, fmt, plain, commas, spaces)
+						if strings.Contains(content, val) {
+							count++
+						}
+					}
+					if count > bestCount {
+						bestFmt, bestPlain, bestCommas, bestSpaces = fmt, plain, commas, spaces
+						bestCount = count
+					}
+				}
+			}
+		}
+	}
+
+	return bestFmt, bestPlain, bestCommas, bestSpaces
+}
+
+func createTemplates(opts *DeriveOpts) error {
+	files, err := builder.DiscoverTemplates(opts.Input)
+	if err != nil {
+		return err
+	}
+
+	variant := color.MainVariantMeta
+	switch opts.Variant {
+	case "moon":
+		variant = color.MoonVariantMeta
+	case "dawn":
+		variant = color.DawnVariantMeta
+	}
+
+	for _, file := range files {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+
+		content := string(raw)
+
+		formatStr, plain, commas, spaces := opts.Format, opts.Plain, opts.Commas, opts.Spaces
+		if formatStr == "" {
+			var df color.ColorFormat
+			df, plain, commas, spaces = detectFormatOptions(content, variant)
+			formatStr = string(df)
+		}
+
+		data := []string{}
+
+		for name, c := range variant.Colors {
+			val := color.FormatColor(c, color.ColorFormat(formatStr), plain, commas, spaces)
+			data = append(data, val, opts.Prefix+name)
+		}
+
+		data = append(data, variant.Id, opts.Prefix+"id")
+		data = append(data, variant.Name, opts.Prefix+"name")
+		data = append(data, variant.Description, opts.Prefix+"description")
+
+		result := strings.NewReplacer(data...).Replace(content)
+
+		if content == result {
+			fmt.Printf("%sNo matches for format %q. Available formats:\n  %s%s\n", warnColor, formatStr, strings.Join(color.AllFormats, ", "), resetColor)
+		}
+
+		ext := filepath.Ext(file)
+		outputFile := "template" + ext
+		outputPath := filepath.Join(opts.Output, outputFile)
+
+		opts.DetectedFormat = formatStr
+		opts.TemplatePath = outputPath
+
+		if err := writeFile(outputPath, []byte(result)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeFile(outputPath string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, content, 0644)
+}

--- a/derive/derive_test.go
+++ b/derive/derive_test.go
@@ -1,0 +1,285 @@
+package derive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rose-pine/rose-pine-bloom/color"
+)
+
+var testOpts = DeriveOpts{
+	Input:   "",
+	Output:  "",
+	Variant: "moon",
+	Prefix:  "$",
+	Format:  "hex",
+	Plain:   false,
+	Commas:  true,
+	Spaces:  true,
+}
+
+func setupTest(t *testing.T) string {
+	tmpDir, err := os.MkdirTemp("", "rose-pine-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+	return tmpDir
+}
+
+func BenchmarkDetectFormatOptions(b *testing.B) {
+	content := `{"base": "#191724", "love": "#eb6f92"}`
+	for b.Loop() {
+		detectFormatOptions(content, color.MainVariantMeta)
+	}
+}
+
+
+func TestDetectFormatOptions(t *testing.T) {
+	colors := func(base, love string) string {
+		return fmt.Sprintf(`{"base": "%s", "love": "%s"}`, base, love)
+	}
+
+	tests := []struct {
+		name       string
+		content    string
+		wantFormat color.ColorFormat
+		wantPlain  bool
+		wantCommas bool
+		wantSpaces bool
+	}{
+		{
+			name:       "hex with hash",
+			content:    colors("#191724", "#eb6f92"),
+			wantFormat: color.FormatHex,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "hex plain",
+			content:    colors("191724", "eb6f92"),
+			wantFormat: color.FormatHex,
+			wantPlain:  true,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "rgb function",
+			content:    colors("rgb(25, 23, 36)", "rgb(235, 111, 146)"),
+			wantFormat: color.FormatRGB,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "rgb no spaces",
+			content:    colors("rgb(25,23,36)", "rgb(235,111,146)"),
+			wantFormat: color.FormatRGB,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: false,
+		},
+		{
+			name:       "rgb no commas",
+			content:    colors("rgb(25 23 36)", "rgb(235 111 146)"),
+			wantFormat: color.FormatRGB,
+			wantPlain:  false,
+			wantCommas: false,
+			wantSpaces: true,
+		},
+		{
+			name:       "hsl function",
+			content:    colors("hsl(249, 22%, 12%)", "hsl(343, 76%, 68%)"),
+			wantFormat: color.FormatHSL,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "hsl no spaces",
+			content:    colors("hsl(249,22%,12%)", "hsl(343,76%,68%)"),
+			wantFormat: color.FormatHSL,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: false,
+		},
+		{
+			name:       "hsl css",
+			content:    colors("hsl(249deg 22% 12%)", "hsl(343deg 76% 68%)"),
+			wantFormat: color.FormatHSLCSS,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "ansi",
+			content:    colors("25;23;36", "235;111;146"),
+			wantFormat: color.FormatAnsi,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+		{
+			name:       "fallback on no match",
+			content:    "no colors here at all",
+			wantFormat: color.FormatHex,
+			wantPlain:  false,
+			wantCommas: true,
+			wantSpaces: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFormat, gotPlain, gotCommas, gotSpaces := detectFormatOptions(tt.content, color.MainVariantMeta)
+			if gotFormat != tt.wantFormat {
+				t.Errorf("format = %q, want %q", gotFormat, tt.wantFormat)
+			}
+			if gotPlain != tt.wantPlain {
+				t.Errorf("plain = %v, want %v", gotPlain, tt.wantPlain)
+			}
+			if gotCommas != tt.wantCommas {
+				t.Errorf("commas = %v, want %v", gotCommas, tt.wantCommas)
+			}
+			if gotSpaces != tt.wantSpaces {
+				t.Errorf("spaces = %v, want %v", gotSpaces, tt.wantSpaces)
+			}
+		})
+	}
+}
+
+func TestCreateAutoDetect(t *testing.T) {
+	tests := []struct {
+		name    string
+		variant string
+		input   string
+		format  string
+		wantVal string
+	}{
+		{
+			name:    "auto-detect hex",
+			variant: "moon",
+			input:   `"base": "#232136"`,
+			format:  "",
+			wantVal: "$base",
+		},
+		{
+			name:    "auto-detect hsl",
+			variant: "moon",
+			input:   `"base": "hsl(246, 24%, 17%)"`,
+			format:  "",
+			wantVal: "$base",
+		},
+		{
+			name:    "auto-detect rgb",
+			variant: "moon",
+			input:   `"base": "rgb(35, 33, 54)"`,
+			format:  "",
+			wantVal: "$base",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := setupTest(t)
+
+			fileContent := "{\n  " + tt.input + "\n}"
+			filePath := filepath.Join(tmpDir, "input.json")
+			if err := os.WriteFile(filePath, []byte(fileContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			opts := testOpts
+			opts.Output = tmpDir
+			opts.Input = filePath
+			opts.Format = tt.format
+			opts.Variant = tt.variant
+
+			if err := DeriveTemplate(&opts); err != nil {
+				t.Fatal(err)
+			}
+
+			content, err := os.ReadFile(filepath.Join(tmpDir, "template.json"))
+			if err != nil {
+				t.Fatalf("Failed to read generated file: %v", err)
+			}
+			if !strings.Contains(string(content), tt.wantVal) {
+				t.Errorf("generated template should contain %q, got:\n%s", tt.wantVal, string(content))
+			}
+		})
+	}
+}
+
+func TestCreate(t *testing.T) {
+	tmpDir := setupTest(t)
+
+	fileContent := `{
+  "base": "#232136",
+  "surface": "#2a273f",
+  "overlay": "#393552",
+  "muted": "#6e6a86",
+  "subtle": "#908caa",
+  "text": "#e0def4",
+  "love": "#eb6f92",
+  "gold": "#f6c177",
+  "rose": "#ea9a97",
+  "pine": "#3e8fb0",
+  "foam": "#9ccfd8",
+  "iris": "#c4a7e7",
+  "main-id": "rose-pine",
+  "id": "rose-pine-moon",
+  "name": "Rosé Pine Moon",
+  "description": "All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+  "dawn-name": "Rosé Pine Dawn"
+}`
+	expected := `{
+  "base": "$base",
+  "surface": "$surface",
+  "overlay": "$overlay",
+  "muted": "$muted",
+  "subtle": "$subtle",
+  "text": "$text",
+  "love": "$love",
+  "gold": "$gold",
+  "rose": "$rose",
+  "pine": "$pine",
+  "foam": "$foam",
+  "iris": "$iris",
+  "main-id": "rose-pine",
+  "id": "$id",
+  "name": "$name",
+  "description": "$description",
+  "dawn-name": "Rosé Pine Dawn"
+}`
+
+	filePath := filepath.Join(tmpDir, "input.json")
+	if err := os.WriteFile(filePath, []byte(fileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := testOpts
+	opts.Output = tmpDir
+	opts.Input = filePath
+
+	if err := DeriveTemplate(&opts); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("template.json", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, "template.json"))
+		if err != nil {
+			t.Fatalf("Failed to read generated file: %v", err)
+		}
+		if string(content) != expected {
+			t.Errorf("want %s\n\n got %s", expected, string(content))
+		}
+	})
+}


### PR DESCRIPTION
Gave the template builder a big overhaul, which should make way for a few upcoming features.

The main changes:                                                                                                                                 
 - Split `builder.go` into separate files: `scan.go` handles template scanning into structured Capture types (role, meta, variant, text), and `substitute.go` builds the final theme in one pass by walking the captures
 - Pulled the "derive template from existing theme" logic out into its own derive package, since it's a distinct concern from building
 - Regex-based alpha parsing is gone, replaced with a scanner that handles prefix/alpha syntax directly
                                                                                                                                        
There should be no behavioral changes, except that the prefix can now only be a single character, if there are any themes using this feature this could still be added

I also ran a simple benchmark which shows it's a bit faster now (especially when generating multiple variants/accents)

```
$ go test ./builder/ -bench=BenchmarkOldProcessTemplate\|BenchmarkNewScanAndSubstitute -benchmem -count=3 -run='^$'                                
goos: darwin                                                                                                                                       
goarch: arm64                                                                                                                                      
pkg: github.com/rose-pine/rose-pine-bloom/builder                        
cpu: Apple M5 Max                                                        
BenchmarkOldProcessTemplate-18             15181             75396 ns/op          122456 B/op        615 allocs/op                                 
BenchmarkOldProcessTemplate-18             16287             73460 ns/op          122454 B/op        615 allocs/op                                 
BenchmarkOldProcessTemplate-18             16237             73747 ns/op          122461 B/op        615 allocs/op                                 
BenchmarkNewScanAndSubstitute-18           66666             17470 ns/op           46160 B/op        785 allocs/op                                 
BenchmarkNewScanAndSubstitute-18           69098             17335 ns/op           46160 B/op        785 allocs/op                                 
BenchmarkNewScanAndSubstitute-18           69043             17296 ns/op           46160 B/op        785 allocs/op                                 
PASS                                                                     
ok      github.com/rose-pine/rose-pine-bloom/builder    7.465s
```

I don't write go often, so let me know if there is anything i can improve :)